### PR TITLE
Add link to compiled binaries in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ James is build with [hoxy](https://github.com/greim/hoxy), [electron](https://gi
 
 ![](resource/screenshot-1.png)
 
+## Installing
+Pre-compiled binaries are available under the [releases](https://github.com/james-proxy/james/releases) tab.
+
+Just download the appropriate one for your system and run it.
+
 ## Running in a development environment
 
  1. Clone the repository

--- a/README.md
+++ b/README.md
@@ -12,11 +12,7 @@ James is build with [hoxy](https://github.com/greim/hoxy), [electron](https://gi
 ## Installing
 Download the correct version for your OS and run
 
-[![OSX download](https://img.shields.io/badge/download-OSX-green.svg)](https://github.com/james-proxy/james/releases/download/v1.3.2/James-darwin-x64.zip)
-[![Linux x86 download](https://img.shields.io/badge/download-linux--ia32-green.svg)](https://github.com/james-proxy/james/releases/download/v1.3.2/James-linux-ia32.zip)
-[![Linux x64 download](https://img.shields.io/badge/download-linux--x64-green.svg)](https://github.com/james-proxy/james/releases/download/v1.3.2/James-linux-x64.zip)
-[![Windows x86 download](https://img.shields.io/badge/download-windows--ia32-green.svg)](https://github.com/james-proxy/james/releases/download/v1.3.2/James-win32-ia32.zip)
-[![Windows x64 download](https://img.shields.io/badge/download-windows--x64-green.svg)](https://github.com/james-proxy/james/releases/download/v1.3.2/James-win32-x64.zip)
+[![All platforms download](https://img.shields.io/badge/download-any_platform-green.svg)](https://github.com/james-proxy/james/releases/latest)
 
 ## Running in a development environment
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ James is build with [hoxy](https://github.com/greim/hoxy), [electron](https://gi
 ## Installing
 Download the correct version for your OS and run
 
-![](https://img.shields.io/badge/download-OSX-green.svg?link=https://github.com/james-proxy/james/releases/download/v1.3.2/James-darwin-x64.zip)
-![](https://img.shields.io/badge/download-linux--ia32-green.svg?link=https://github.com/james-proxy/james/releases/download/v1.3.2/James-linux-ia32.zip)
-![](https://img.shields.io/badge/download-linux--x64-green.svg?link=https://github.com/james-proxy/james/releases/download/v1.3.2/James-linux-x64.zip)
-![](https://img.shields.io/badge/download-windows--ia32-green.svg?https://github.com/james-proxy/james/releases/download/v1.3.2/James-win32-ia32.zip)
-![](https://img.shields.io/badge/download-windows--x64-green.svg?https://github.com/james-proxy/james/releases/download/v1.3.2/James-win32-x64.zip)
+[![OSX download](https://img.shields.io/badge/download-OSX-green.svg)](https://github.com/james-proxy/james/releases/download/v1.3.2/James-darwin-x64.zip)
+[![Linux x86 download](https://img.shields.io/badge/download-linux--ia32-green.svg)](https://github.com/james-proxy/james/releases/download/v1.3.2/James-linux-ia32.zip)
+[![Linux x64 download](https://img.shields.io/badge/download-linux--x64-green.svg)](https://github.com/james-proxy/james/releases/download/v1.3.2/James-linux-x64.zip)
+[![Windows x86 download](https://img.shields.io/badge/download-windows--ia32-green.svg)](https://github.com/james-proxy/james/releases/download/v1.3.2/James-win32-ia32.zip)
+[![Windows x64 download](https://img.shields.io/badge/download-windows--x64-green.svg)](https://github.com/james-proxy/james/releases/download/v1.3.2/James-win32-x64.zip)
 
 ## Running in a development environment
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ James is build with [hoxy](https://github.com/greim/hoxy), [electron](https://gi
 ![](resource/screenshot-1.png)
 
 ## Installing
-Pre-compiled binaries are available under the [releases](https://github.com/james-proxy/james/releases) tab.
+Download the correct version for your OS and run
 
-Just download the appropriate one for your system and run it.
+![](https://img.shields.io/badge/download-OSX-green.svg?link=https://github.com/james-proxy/james/releases/download/v1.3.2/James-darwin-x64.zip)
+![](https://img.shields.io/badge/download-linux--ia32-green.svg?link=https://github.com/james-proxy/james/releases/download/v1.3.2/James-linux-ia32.zip)
+![](https://img.shields.io/badge/download-linux--x64-green.svg?link=https://github.com/james-proxy/james/releases/download/v1.3.2/James-linux-x64.zip)
+![](https://img.shields.io/badge/download-windows--ia32-green.svg?https://github.com/james-proxy/james/releases/download/v1.3.2/James-win32-ia32.zip)
+![](https://img.shields.io/badge/download-windows--x64-green.svg?https://github.com/james-proxy/james/releases/download/v1.3.2/James-win32-x64.zip)
 
 ## Running in a development environment
 


### PR DESCRIPTION
I actually missed this when first trying it out. 
Thought it was really weird that you had to run it from the CLI....

Not really sure about the text tho. 
Any suggestions? 
Link directly to the compiled files?