### PR TITLE
Replace close shortcut to use 'Q' instead of 'W'

### DIFF
--- a/src/menu.js
+++ b/src/menu.js
@@ -61,7 +61,7 @@ function menuTempl() {
       },
       {
         label: 'Close',
-        accelerator: 'CommandOrControl+W',
+        accelerator: 'CommandOrControl+Q',
         role: 'close'
       },
       {


### PR DESCRIPTION
It makes sense: it closes an application, not a window of the application