### PR TITLE
Fix `package-browserify`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,6 +13,7 @@ const source = require('vinyl-source-stream');
 const electron = require('electron-packager');
 const useref = require('gulp-useref');
 const electronConnect = require('electron-connect').server.create();
+const exec = require('child_process').exec;
 
 gulp.task('default', ['js', 'css', 'resources']);
 
@@ -58,16 +59,12 @@ gulp.task('package-resources', ['default'], () => {
   ]);
 });
 
-gulp.task('package-browserify', ['default'], () => {
-  return browserify('./build/index.js', {
-    builtins: false, // Attempt to reproduce
-    browserField: false // the `--node` flag
+gulp.task('package-browserify', ['default'], (cb) => {
+  exec('browserify --node -e build/index.js -o ./package/index.js -u remote -u child-killer', (err, stdout, stderr) => {
+    console.log(stdout);
+    console.error(stderr);
+    cb(err);
   })
-    .exclude('remote')
-    .exclude('child-killer')
-    .bundle()
-    .pipe(source('index.js')).
-    pipe(gulp.dest('./package/'))
 });
 
 gulp.task('package', ['package-resources', 'package-browserify'], (done) => {


### PR DESCRIPTION
Earlier, when `gulpifying`, I moved executing `browserify` to JS. It wasn't accepting the `node: true` argument, so I looked at [it's source code](https://github.com/substack/node-browserify/blob/master/bin/cmd.js) to reproduce it using its sub-properties. However, it still wasn't removing the `require('_process')` bits, so in this PR I'm just calling the CLI version from the gulpfile.

I would move this back to the `NPM` script, but then I'd have to pull out `package-resources`, too, which would involve removing `electron-connect` (because we need to remove the connect bit from the HTML in the gulpfile's `package-resources`, and that occurs using `gulp-useref`)