### PR TITLE
Misc minor UI cleanup

### DIFF
--- a/src/component/footer.js
+++ b/src/component/footer.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import {CacheButton} from './footer/cache';
+import CacheButton from './footer/cache';
 import Throttle from './footer/throttle';
-import {RequestCount} from './footer/requestCount';
+import RequestCount from './footer/request-count';
 
 const {func, object} = React.PropTypes;
 
-export const Footer = (props) => {
+const Footer = (props) => {
   const {
     toggleCaching,
     isCachingEnabled,
@@ -27,3 +27,5 @@ Footer.propTypes = {
   clearRequests: func.isRequired,
   requestData: object.isRequired
 };
+
+export default Footer;

--- a/src/component/footer.js
+++ b/src/component/footer.js
@@ -1,43 +1,25 @@
 import React from 'react';
-import Throttle from './footer-throttle';
+import {CacheButton} from './footer/cache';
+import Throttle from './footer/throttle';
+import {RequestCount} from './footer/requestCount';
 
 const {func, object} = React.PropTypes;
 
-export default class Footer extends React.Component {
+export const Footer = (props) => {
+  const {
+    toggleCaching,
+    isCachingEnabled,
+    clearRequests,
+    requestData,
+    ...other
+  } = props;
 
-  render() {
-    const {
-      toggleCaching,
-      isCachingEnabled,
-      clearRequests,
-      requestData,
-      ...other
-      } = this.props;
-
-    let cachingButton = <span>
-      <i className="fa fa-circle-o"/>
-      Caching disabled
-    </span>;
-
-    if (isCachingEnabled()) {
-      cachingButton = <span>
-        <i className="fa fa-circle"/>
-        Caching enabled
-      </span>;
-    }
-
-    return <div className="footer">
-      <button onClick={toggleCaching}>{cachingButton}</button>
-      <Throttle {...other} />
-      <div className="request-count">
-        Requests: {requestData.filteredCount}/{requestData.totalCount}
-        <button onClick={clearRequests}>
-          <i className="fa fa-ban" />
-        </button>
-      </div>
-    </div>;
-  }
-}
+  return <div className="footer">
+    <CacheButton isCachingEnabled={isCachingEnabled} toggleCaching={toggleCaching} />
+    <Throttle {...other} />
+    <RequestCount requestData={requestData} clearRequests={clearRequests} />
+  </div>;
+};
 
 Footer.propTypes = {
   toggleCaching: func.isRequired,

--- a/src/component/footer/cache.js
+++ b/src/component/footer/cache.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const {bool, func} = React.PropTypes;
+
+export const CacheButton = ({isCachingEnabled, toggleCaching}) => {
+  const enabled = isCachingEnabled();
+  const icon = enabled ? 'fa fa-circle' : 'fa fa-circle-o';
+  const label = enabled ? 'Caching enabled' : 'Caching disabled';
+
+  return <button title="Toggle caching" onClick={toggleCaching}>
+    <i className={icon} />
+    {label}
+  </button>;
+};
+
+CacheButton.propTypes = {
+  isCachingEnabled: bool.isRequired,
+  toggleCaching: func.isRequired
+};

--- a/src/component/footer/cache.js
+++ b/src/component/footer/cache.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const {func} = React.PropTypes;
 
-export const CacheButton = ({isCachingEnabled, toggleCaching}) => {
+const CacheButton = ({isCachingEnabled, toggleCaching}) => {
   const enabled = isCachingEnabled();
   const icon = enabled ? 'fa fa-circle' : 'fa fa-circle-o';
   const label = enabled ? 'Caching enabled' : 'Caching disabled';
@@ -17,3 +17,5 @@ CacheButton.propTypes = {
   isCachingEnabled: func.isRequired,
   toggleCaching: func.isRequired
 };
+
+export default CacheButton;

--- a/src/component/footer/cache.js
+++ b/src/component/footer/cache.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const {bool, func} = React.PropTypes;
+const {func} = React.PropTypes;
 
 export const CacheButton = ({isCachingEnabled, toggleCaching}) => {
   const enabled = isCachingEnabled();
@@ -14,6 +14,6 @@ export const CacheButton = ({isCachingEnabled, toggleCaching}) => {
 };
 
 CacheButton.propTypes = {
-  isCachingEnabled: bool.isRequired,
+  isCachingEnabled: func.isRequired,
   toggleCaching: func.isRequired
 };

--- a/src/component/footer/request-count.js
+++ b/src/component/footer/request-count.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const {object, func} = React.PropTypes;
 
-export const RequestCount = ({requestData, clearRequests}) => {
+const RequestCount = ({requestData, clearRequests}) => {
   const {filteredCount, totalCount} = requestData;
   return <div className="request-count">
     {`Requests: ${filteredCount} / ${totalCount}`}
@@ -16,3 +16,5 @@ RequestCount.propTypes = {
   requestData: object.isRequired,
   clearRequests: func.isRequired
 };
+
+export default RequestCount;

--- a/src/component/footer/requestCount.js
+++ b/src/component/footer/requestCount.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const {object, func} = React.PropTypes;
+
+export const RequestCount = ({requestData, clearRequests}) => {
+  const {filteredCount, totalCount} = requestData;
+  return <div className="request-count">
+    {`Requests: ${filteredCount} / ${totalCount}`}
+    <button title="Clear all requests" onClick={clearRequests}>
+      <i className="fa fa-ban" />
+    </button>
+  </div>;
+};
+
+RequestCount.propTypes = {
+  requestData: object.isRequired,
+  clearRequests: func.isRequired
+};

--- a/src/component/footer/throttle.js
+++ b/src/component/footer/throttle.js
@@ -34,7 +34,7 @@ export default class Throttle extends React.Component {
     const icon = this.state.enabled ? 'fa fa-circle' : 'fa fa-circle-o';
 
     return <div className="throttle">
-      <button onClick={this.toggleThrottle.bind(this)}>
+      <button title="Toggle throttling" onClick={this.toggleThrottle.bind(this)}>
         <i className={icon}/>
         Throttle to (kBps):
       </button>

--- a/src/component/main-content.js
+++ b/src/component/main-content.js
@@ -43,6 +43,13 @@ export default class MainContent extends React.Component {
       });
     };
 
+    const isRequestActive = (request) => {
+      if (!activeRequest) {
+        return false;
+      }
+      return request.request.id === activeRequest.request.id;
+    };
+
     let activeRequestNode = null;
     if (activeRequest) {
       activeRequestNode = <InspectRequest
@@ -74,6 +81,7 @@ export default class MainContent extends React.Component {
         requestData={requestData}
         showWindow={showWindow}
         config={config}
+        isRequestActive={isRequestActive}
         setActiveRequest={setActiveRequest}
         setFromIndex={setFromIndex}
         removeUrlMapping={removeUrlMapping}

--- a/src/component/request.js
+++ b/src/component/request.js
@@ -2,7 +2,7 @@ import React from 'react';
 import FullUrl from './full-url.js';
 import ContextMenu from './context-menu.js';
 
-const {func, object, number} = React.PropTypes;
+const {func, object, number, bool} = React.PropTypes;
 
 export default class Request extends React.Component {
   constructor() {
@@ -16,6 +16,7 @@ export default class Request extends React.Component {
   shouldComponentUpdate(nextProps) {
     return this.props.request.id !== nextProps.request.id ||
       this.props.positionTop !== nextProps.positionTop ||
+      this.props.isActive !== nextProps.isActive ||
       this.done !== nextProps.request.done;
   }
 
@@ -65,13 +66,26 @@ export default class Request extends React.Component {
   }
 
   render() {
-    const {request, response, showWindow, positionTop, removeUrlMapping, toggleUrlMappingActiveState} = this.props;
+    const {
+      request,
+      response,
+      isActive,
+      showWindow,
+      positionTop,
+      removeUrlMapping,
+      toggleUrlMappingActiveState
+    } = this.props;
 
     this.done = request.done;
 
     let took = <i className="fa fa-gear fa-spin"></i>;
     if (request.took) {
       took = request.took + 'ms';
+    }
+
+    const requestClasses = ['request'];
+    if (isActive) {
+      requestClasses.push('request-active');
     }
 
     const style = {
@@ -108,7 +122,7 @@ export default class Request extends React.Component {
       });
     }
 
-    return <div className="request" style={style}>
+    return <div className={requestClasses.join(' ')} style={style}>
       { this.state.isContextMenuActive &&
         <ContextMenu items={contextMenuItems}/>
       }
@@ -134,6 +148,7 @@ Request.propTypes = {
   config: object.isRequired,
   request: object.isRequired,
   response: object.isRequired,
+  isActive: bool.isRequired,
   handleClick: func.isRequired,
   showWindow: func.isRequired,
   positionTop: number.isRequired,

--- a/src/component/requests.js
+++ b/src/component/requests.js
@@ -46,6 +46,7 @@ export default class Requests extends React.Component {
 
   render() {
     const {
+      isRequestActive,
       setActiveRequest,
       showWindow,
       config,
@@ -61,9 +62,12 @@ export default class Requests extends React.Component {
         setActiveRequest(request);
       };
 
+      const isActive = isRequestActive(request);
+
       const positionTop = request.requestNumber * requestElementHeight;
       return <Request
         {...request}
+        isActive={isActive}
         positionTop={positionTop}
         config={config}
         showWindow={showWindow}
@@ -89,10 +93,10 @@ Requests.propTypes = {
   requestData: object.isRequired,
   showWindow: func.isRequired,
   filter: string,
+  isRequestActive: func.isRequired,
   setActiveRequest: func.isRequired,
   setFromIndex: func.isRequired,
   config: object.isRequired,
   removeUrlMapping: func.isRequired,
   toggleUrlMappingActiveState: func.isRequired
 };
-

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import hoxy from 'hoxy';
 import TitleBar from './component/titlebar';
-import Footer from './component/footer';
+import {Footer} from './component/footer';
 import MainContent from './component/main-content.js';
 import Proxy from './service/proxy.js';
 import createChooseFile from './service/choose-file.js';
@@ -51,7 +51,7 @@ const createHoxy = () => {
     const cert = fs.readFileSync('./root-ca.crt.pem');
     opts.certAuthority = {key, cert};
   } catch (e) {
-    console.log('Not proxying HTTPS, missing key or certificate: ' + e); // eslint-disable-line
+    console.warn('Not proxying HTTPS, missing key or certificate:\n', e); // eslint-disable-line
   }
 
   return hoxy.createServer(opts).listen(config.proxyPort);

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import hoxy from 'hoxy';
 import TitleBar from './component/titlebar';
-import {Footer} from './component/footer';
+import Footer from './component/footer';
 import MainContent from './component/main-content.js';
 import Proxy from './service/proxy.js';
 import createChooseFile from './service/choose-file.js';

--- a/style/components/_inspect-request.scss
+++ b/style/components/_inspect-request.scss
@@ -9,16 +9,15 @@
   background: rgba($lightgray-light, 0.9);
 
   .toolbar {
-    position: absolute;
-    top: -42px;
-    right: 0;
-    left: 0;
-    text-align: right;
+    float: right;
+    margin-top: -40px;
+    padding: 0 5px;
 
     .toolbar-action {
       display: inline-block;
       background: darken($darkgray-light, 10%);
       color: $white;
+      height: 40px;
       border-radius: 8px 8px 0 0;
       margin-left: 3px;
       padding: 10px;

--- a/style/components/_requests.scss
+++ b/style/components/_requests.scss
@@ -33,6 +33,10 @@
       }
     }
 
+    &.request-active .complete-url {
+      font-weight: bold;
+    }
+
     &:hover {
       cursor: pointer;
       background-color: $lightgray-light;


### PR DESCRIPTION
@mitchhentges pointed me towards this project, so I had a look around!

Noticed a few things that could use fixing:

- At first, wasn't completely sure what the random :no_entry_sign: in the bottom right did. Hovered over... nothing. So, I added a tooltip! The rest of the footer didn't have tooltips either, and there were a bunch of toggles. Best not to assume everyone realises they're buttons. So, tooltip all the things!
![image](https://cloud.githubusercontent.com/assets/4513759/12707489/e9f87388-c849-11e5-9935-f9fe28ae5919.png)

- While I was in the footer, I realised it could take advantage of React 0.14's [stateless components](https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html#stateless-functional-components). I was going to change `Throttle` as well, since it seems like it should be stateless as well, but that wasn't immediately working. I'll try to poke at it later, since I believe all the state should be higher up.

- While inspecting a request, the toolbar that contains close has an invisible overlay that prevents you from clicking or scrolling on elements underneath. That's fixed as well.

- Speaking of the close button, I noticed it had some alignment issues (#85) and fixed that as well. Also gave it a bit of `margin` from the sides so it didn't look awkward.
![image](https://cloud.githubusercontent.com/assets/4513759/12707522/3173a57a-c84a-11e5-8a2e-fd6ba32a0841.png)

- In the list of requests, you can't really tell which one you're inspecting. So when you're looking at a bunch of similar or even identical requests, you're sorta out of luck. No longer an issue, as the active request is now **bold**.
![image](https://cloud.githubusercontent.com/assets/4513759/12707549/70adf20e-c84a-11e5-8f10-2624e0682de9.png)

Hopefully this isn't too many fixes for a single PR, if so, I can split it up.