### PR TITLE
Put "lint" task back in `package.json`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,6 @@ const changed = require('gulp-changed');
 const sass = require('gulp-sass');
 const sourcemaps = require('gulp-sourcemaps');
 const autoprefixer = require('gulp-autoprefixer');
-const eslint = require('gulp-eslint');
 const browserify = require('browserify');
 const source = require('vinyl-source-stream');
 const electron = require('electron-packager');
@@ -81,13 +80,6 @@ gulp.task('package', ['package-resources', 'package-browserify'], (done) => {
     version: '0.36.5',
     out: 'binaries'
   }, () => done())
-});
-
-gulp.task('lint', () => {
-  return gulp.src(['src/**', 'test/**'])
-    .pipe(eslint())
-    .pipe(eslint.format())
-    .pipe(eslint.failOnError())
 });
 
 gulp.task('clean', () => {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -82,10 +82,6 @@ gulp.task('package', ['package-resources', 'package-browserify'], (done) => {
   }, () => done())
 });
 
-gulp.task('clean', () => {
-  del.sync(['build', 'package', 'binaries']);
-});
-
 gulp.task('watch', ['default'], () => {
   gulp.watch('src/**', ['js']);
   gulp.watch('style/**', ['css']);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "package": "gulp clean package",
     "zip-binaries": "cd binaries; rm *.zip; for i in *; do zip --symlinks -r \"${i%/}.zip\" \"$i\"; done",
     "start": "electron .",
-    "lint": "gulp lint",
+    "lint": "eslint ./src ./test",
     "test": "mocha --reporter dot --recursive -r setup-referee-sinon/globals test/unit --compilers js:babel-core/register",
     "test-ci": "npm run lint && npm run test && npm run package"
   },
@@ -48,7 +48,6 @@
     "gulp-autoprefixer": "^3.1.0",
     "gulp-babel": "^6.1.1",
     "gulp-changed": "^1.3.0",
-    "gulp-eslint": "^1.1.1",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.1.1",
     "gulp-sourcemaps": "^1.6.0",


### PR DESCRIPTION
Sorry for jumping backwards here, but here's what I'm thinking:
* It makes sense to have compilations using `gulp` to take advantage of incremental compiling
* Having `package` in `gulp` is a good idea so that `gulp-useref` can filter dev-only code
* Cleaning works nicely in gulp, because it's platform-agnostic
* Watching is super-easy in gulp, why not use it

However, for things like `eslint` and `mocha`, they don't work incrementally. Putting them in `gulp` just adds unnecessary overhead. By leaving them in `package.json`, it makes things more simple