### PR TITLE
Max height for inspect-request

### DIFF
--- a/style/components/_inspect-request.scss
+++ b/style/components/_inspect-request.scss
@@ -64,7 +64,6 @@
   }
 
   .box-body {
-    max-height: 500px;
     overflow-y: scroll;
   }
 

--- a/style/components/_inspect-request.scss
+++ b/style/components/_inspect-request.scss
@@ -7,6 +7,7 @@
   bottom: 0;
   z-index: 2;
   background: rgba($lightgray-light, 0.9);
+  max-height: 60%;
 
   .toolbar {
     float: right;


### PR DESCRIPTION
Sets max height of inspect-request to prevent it from taking over the whole window and not being able to close the view.

Fixes #100.