### PR TITLE
Fix package (manually include `electron-localshortcut`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "browserify": "^13.0.0",
     "del": "^2.2.0",
     "electron-connect": "^0.3.5",
-    "electron-localshortcut": "^0.6.0",
     "electron-packager": "^5.2.1",
     "electron-prebuilt": "^0.36.5",
     "eslint": "^1.10.3",

--- a/resource/electron-localshortcut.js
+++ b/resource/electron-localshortcut.js
@@ -1,0 +1,149 @@
+'use strict';
+
+const electron = require('electron');
+const globalShortcut = electron.globalShortcut;
+const BrowserWindow = electron.BrowserWindow;
+const app = electron.app;
+const windowsWithShortcuts = new WeakMap();
+
+// a placeholder to register shortcuts
+// on any window of the app.
+const ANY_WINDOW = {};
+
+function isAccelerator(arg) {
+  return typeof arg === 'string';
+}
+
+function unregisterAllShortcuts(win) {
+  const shortcuts = windowsWithShortcuts.get(win);
+  shortcuts.forEach( sc =>
+    globalShortcut.unregister(sc.accelerator)
+  );
+}
+
+function registerAllShortcuts(win) {
+  const shortcuts = windowsWithShortcuts.get(win);
+
+  shortcuts.forEach( sc =>
+    globalShortcut.register(sc.accelerator, sc.callback)
+  );
+}
+
+function unregisterAll(win) {
+  if (win === undefined) {
+    // unregister shortcuts for any window in the app
+    unregisterAll(ANY_WINDOW);
+    return;
+  }
+
+  if (!windowsWithShortcuts.has(win)) {
+    return;
+  }
+
+  unregisterAllShortcuts(win);
+  windowsWithShortcuts.delete(win);
+}
+
+function register(win, accelerator, callback) {
+  if (arguments.length === 2 && isAccelerator(win)) {
+    // register shortcut for any window in the app
+    // win = accelerator, accelerator = callback
+    register(ANY_WINDOW, win, accelerator);
+    return;
+  }
+
+  if (windowsWithShortcuts.has(win)) {
+    const shortcuts = windowsWithShortcuts.get(win);
+    shortcuts.push({
+      accelerator: accelerator,
+      callback: callback
+    });
+  } else {
+    windowsWithShortcuts.set(win, [{
+      accelerator: accelerator,
+      callback: callback
+    }]);
+  }
+
+  const focusedWin = BrowserWindow.getFocusedWindow();
+  if ((win === ANY_WINDOW && focusedWin !== null) || focusedWin === win) {
+    globalShortcut.register(accelerator, callback);
+  }
+}
+
+function indexOfShortcut(win, accelerator) {
+  if (!windowsWithShortcuts.has(win)) {
+    return -1;
+  }
+
+  const shortcuts = windowsWithShortcuts.get(win);
+  let shortcutToUnregisterIdx = -1;
+  shortcuts.some((s, idx) => {
+    if (s.accelerator === accelerator) {
+      shortcutToUnregisterIdx = idx;
+      return true;
+    }
+    return false;
+  });
+  return shortcutToUnregisterIdx;
+}
+
+function unregister(win, accelerator) {
+  if (arguments.length === 1 && isAccelerator(win)) {
+    // unregister shortcut for any window in the app
+    // win = accelerator
+    unregister(ANY_WINDOW, win);
+    return;
+  }
+  const shortcutToUnregisterIdx = indexOfShortcut(win, accelerator);
+
+  if (shortcutToUnregisterIdx !== -1) {
+    globalShortcut.unregister(accelerator);
+    const shortcuts = windowsWithShortcuts.get(win);
+    shortcuts.splice(shortcutToUnregisterIdx);
+  }
+}
+
+function isRegistered(win, accelerator) {
+  if (arguments.length === 1 && isAccelerator(win)) {
+    // check shortcut for any window in the app
+    // win = accelerator
+    return isRegistered(ANY_WINDOW, win);
+  }
+
+  return indexOfShortcut(win, accelerator) !== -1;
+}
+
+
+app.on('browser-window-focus', (e, win) => {
+  if (windowsWithShortcuts.has(ANY_WINDOW)) {
+    registerAllShortcuts(ANY_WINDOW);
+  }
+
+  if (!windowsWithShortcuts.has(win)) {
+    return;
+  }
+
+  registerAllShortcuts(win);
+});
+
+app.on('browser-window-blur', (e, win) => {
+  if (windowsWithShortcuts.has(ANY_WINDOW)) {
+    unregisterAllShortcuts(ANY_WINDOW);
+  }
+
+  if (!windowsWithShortcuts.has(win)) {
+    return;
+  }
+
+  unregisterAllShortcuts(win);
+});
+
+module.exports = {
+  register: register,
+  unregister: unregister,
+  isRegistered: isRegistered,
+  unregisterAll: unregisterAll,
+  enableAll: registerAllShortcuts,
+  disableAll: unregisterAllShortcuts
+};

--- a/resource/electron-localshortcut.js
+++ b/resource/electron-localshortcut.js
@@ -1,3 +1,9 @@
+// commit 497538685305a683d85c92a78ea4a12bbef00a58
+// https://github.com/parro-it/electron-localshortcut
+
+// Electron's `remote.require('...')` always checks the local filesystem (node_modules, etc). So, when trying to
+// `remote.require` something not pre-included in Electron, it fails unless it exists on the local filesystem.
+// So, instead of bundling `electron-localshortcut` with the rest of the JS, it's beside everything in a separate file.
 'use strict';
 
 const electron = require('electron');

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ import remote from 'remote';
 import openBrowser from './open-browser.js';
 
 const browserLauncher = require('browser-launcher2');
-const localShortcut = remote.require('electron-localshortcut');
+const localShortcut = remote.require('./electron-localshortcut.js');
 const app = remote.require('app');
 const fs = remote.require('fs');
 


### PR DESCRIPTION
This is a pretty dirty trick: remove `electron-localshortcut` from `package.json`, throw the JS file in `resource` to be on the "classpath" at runtime.

#yolo