### PR TITLE
Material

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "browser-launcher2": "^0.4.6",
     "hoxy": "^3.2.0",
+    "materialize-css": "^0.97.5",
     "nedb": "^1.7.1",
     "react": "^0.14.6",
     "react-dom": "^0.14.6",

--- a/resource/index.html
+++ b/resource/index.html
@@ -2,8 +2,7 @@
 <html>
 <head lang="en">
     <meta charset="UTF-8">
-    <title></title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.96.1/css/materialize.min.css">
+    <title>James Proxy</title>
     <link href="./james.css" rel="stylesheet">
 </head>
 <body>

--- a/style/components/_requests.scss
+++ b/style/components/_requests.scss
@@ -1,7 +1,7 @@
 .requests {
 
   position: absolute;
-  top: 50px;
+  top: 55px;
   left: 0;
   bottom: 0;
   right: 0;

--- a/style/components/_titlebar.scss
+++ b/style/components/_titlebar.scss
@@ -1,4 +1,6 @@
 .titlebar {
+  @extend .z-depth-2;
+  
   -webkit-app-region: drag;
   position: absolute;
   left: 0;

--- a/style/components/main-content.scss
+++ b/style/components/main-content.scss
@@ -19,14 +19,14 @@
     .search {
       @extend .card;
       margin: 10px;
-      padding: 0 15px;
+      padding: 0;
 
       input[type="text"] {
         margin: 0;
         border: 0;
         box-shadow: none;
         height: 25px;
-        padding: 5px 0;
+        padding: 5px 15px;
       }
     }
   }

--- a/style/components/main-content.scss
+++ b/style/components/main-content.scss
@@ -15,8 +15,20 @@
     left: 0;
     bottom: 0;
     right: 0;
-    height: 40px;
-    padding: 5px;
+
+    .search {
+      @extend .card;
+      margin: 10px;
+      padding: 0 15px;
+
+      input[type="text"] {
+        margin: 0;
+        border: 0;
+        box-shadow: none;
+        height: 25px;
+        padding: 5px 0;
+      }
+    }
   }
 
   h1 {

--- a/style/main.scss
+++ b/style/main.scss
@@ -1,5 +1,8 @@
 $fa-font-path: "fonts" !default;
 
+@import '../node_modules/font-awesome/scss/font-awesome';
+@import '../node_modules/materialize-css/sass/materialize';
+
 @import 'colors';
 @import 'components/titlebar';
 @import 'components/footer';
@@ -8,7 +11,6 @@ $fa-font-path: "fonts" !default;
 @import 'components/context-menu';
 @import 'components/inspect-request';
 @import 'components/windows/url-mapping';
-@import '../node_modules/font-awesome/scss/font-awesome';
 
 @import url(http://fonts.googleapis.com/css?family=Lato:300,400,700);
 @import url(http://fonts.googleapis.com/css?family=Droid+Sans+Mono);


### PR DESCRIPTION
- Quit pointing to CDN for Materialize and make it part of the build. This will allow for using `extend`, without having to pollute markup, and allows for fully local (offline) use now.
- Added depth to the header and search

![image](https://cloud.githubusercontent.com/assets/4513759/12835551/1dcd4610-cb66-11e5-84a4-dae7fecf1218.png)

**WIP:**
- [x] Header
- [x] Search