### PR TITLE
Fix footer overlap

### DIFF
--- a/src/component/inspect-request.js
+++ b/src/component/inspect-request.js
@@ -6,6 +6,11 @@ const {func, object} = React.PropTypes;
 
 export default class InspectRequest extends React.Component {
 
+  constructor() {
+    super();
+    this._onResize = this._onResize.bind(this);
+  }
+
   _getMaxHeight() {
     return window.innerHeight * 0.6 - 100;
   }
@@ -23,11 +28,11 @@ export default class InspectRequest extends React.Component {
   }
 
   componentDidMount() {
-    window.addEventListener('resize', this._onResize.bind(this));
+    window.addEventListener('resize', this._onResize);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this._onResize.bind(this));
+    window.removeEventListener('resize', this._onResize);
   }
 
   render() {

--- a/src/component/inspect-request.js
+++ b/src/component/inspect-request.js
@@ -6,13 +6,32 @@ const {func, object} = React.PropTypes;
 
 export default class InspectRequest extends React.Component {
 
+  _getMaxHeight() {
+    return window.innerHeight * 0.6 - 100;
+  }
+
+  _onResize() {
+    const maxHeight = this._getMaxHeight();
+    this.setState({maxHeight});
+  }
+
   componentWillMount() {
     this.setState({
-      showUrlMapperWindow: false
+      showUrlMapperWindow: false,
+      maxHeight: this._getMaxHeight()
     });
   }
 
+  componentDidMount() {
+    window.addEventListener('resize', this._onResize.bind(this));
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this._onResize.bind(this));
+  }
+
   render() {
+    const {maxHeight} = this.state;
     const {request, setActiveRequest} = this.props;
     const close = () => {
       setActiveRequest(null);
@@ -26,6 +45,8 @@ export default class InspectRequest extends React.Component {
     const requestHeaders = keyValues(request.request.headers);
     const responseHeaders = keyValues(request.response.headers);
 
+    const bodyStyle = {maxHeight};
+
     return <div className="inspect-request">
       <div className="toolbar">
         <div className="toolbar-action primary" onClick={close}>
@@ -38,7 +59,7 @@ export default class InspectRequest extends React.Component {
           {request.request.hostname}
         </div>
       </div>
-      <div className="box-body">
+      <div className="box-body" style={bodyStyle}>
         <section>
           Request URL:
           <code>

--- a/style/components/_inspect-request.scss
+++ b/style/components/_inspect-request.scss
@@ -7,7 +7,6 @@
   bottom: 0;
   z-index: 2;
   background: rgba($lightgray-light, 0.9);
-  max-height: 60%;
 
   .toolbar {
     float: right;
@@ -65,6 +64,7 @@
 
   .box-body {
     overflow-y: scroll;
+    /* max-height set via component */
   }
 
   section {


### PR DESCRIPTION
Overlooked this issue in #108, was too distracted by figuring out the effects of the two heights to realise I completely broke scrolling and had some overlap in the process. Yay for absolute positioning, which doesn't care about it's surroundings. :anguished: 

Unfortunately, for this to work out, there needs to be a height in `box-body` (which is why it was there earlier, duh) and it can't be a percentage, because that becomes irrelevant with absolute positioning.

So, as a fix for now, I'm calculating the percentage on window `resize`. There's similar shenanigans going on in `<Requests />`, which sets the height of `requests-inner`... neither are really optimal.

![image](https://cloud.githubusercontent.com/assets/4513759/12870987/69f1ef04-cd15-11e5-8390-98af33cc166b.png)