### PR TITLE
Fix for protocol

### DIFF
--- a/src/component/requests/full-url.js
+++ b/src/component/requests/full-url.js
@@ -23,7 +23,7 @@ const FullUrl = (props) => {
   }
 
   return <div className="complete-url">
-    <span className="protocol">{request.protocol}</span>
+    <span className="protocol">{request.protocol + '//'}</span>
     <span className="hostname">{request.hostname}</span>
     {port}
     <span className="url">{_shorten(request.url, maxUrlLength)}</span>


### PR DESCRIPTION
Apparently hoxy returns protocol as `http:` with the colon, but not the slashes? Sure..

Feel like it should just be `http` but I guess hoxy's author had their reasons.

nb: Github's syntax highlighting is misleading; that's not a comment. Escaping as `\/\/` will show as-is.