### PR TITLE
Fix #125 (electron X11 can't handle registering command)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -138,8 +138,8 @@ keyboard.register('Esc', closeWindow);
 keyboard.register('CommandOrControl+U', () => showWindow('UrlMapping'));
 keyboard.register('F12', devTools.toggle.bind(devTools));
 keyboard.register('Ctrl+Shift+I', devTools.toggle.bind(devTools));
-keyboard.register('Command+Alt+I', devTools.toggle.bind(devTools));
-keyboard.register('Command+Alt+U', devTools.toggle.bind(devTools));
+keyboard.register('CommandOrControl+Alt+I', devTools.toggle.bind(devTools));
+keyboard.register('CommandOrControl+Alt+U', devTools.toggle.bind(devTools));
 
 /**
  * Set the index of the first request from where we start rendering.


### PR DESCRIPTION
Instead of registering `Command+Alt+I`, I register `CommandOrControl+Alt+I`.