### PR TITLE
Hoxy error makes scary icon after enough time

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,7 @@ const createHoxy = () => {
 
   const hoxyServer = hoxy.createServer(opts);
   hoxyServer.on('error', (event) => {
-    console.warn('hoxy error: ', event);
+    console.warn('hoxy error: ', event); // eslint-disable-line
     if (event.code === 'EADDRINUSE') {
       data.proxyStatus = constants.PROXY_STATUS_ERROR_ADDRESS_IN_USE;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,7 @@ const createHoxy = () => {
 
   const hoxyServer = hoxy.createServer(opts);
   hoxyServer.on('error', (event) => {
-    data.proxyStatus = constants.PROXY_STATUS_ERROR_GENERIC;
+    console.warn('hoxy error: ', event);
     if (event.code === 'EADDRINUSE') {
       data.proxyStatus = constants.PROXY_STATUS_ERROR_ADDRESS_IN_USE;
     }


### PR DESCRIPTION
When an address can't be resolved (e.g. `uxebu.com` makes a request to "http://mhtmuos"), don't show a spooky error in James