### PR TITLE
Search both mapped url and original url

### DIFF
--- a/src/service/proxy.js
+++ b/src/service/proxy.js
@@ -82,7 +82,7 @@ export default class Proxy {
   getRequestData(filter) {
     const filteredRequests = !filter ? this._requests : this._requests
       .filter((request) => {
-        return request.request.fullUrl().indexOf(filter) !== -1;
+        return request.request.fullUrl().includes(filter) || request.request.original.fullUrl.includes(filter);
       });
 
     return {


### PR DESCRIPTION
Right now, search only applies to `request.fullUrl()`. This isn't super-consistent on mapped requests - if searching for the original URL, the request won't match.

As of this PR, filtering applies to both original URL and mapped URL