### PR TITLE
Update electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "electron-connect": "^0.3.5",
     "electron-localshortcut": "^0.6.0",
     "electron-packager": "^5.2.1",
-    "electron-prebuilt": "^0.36.5",
+    "electron-prebuilt": "^0.37.2",
     "eslint": "^2.2.0",
     "eslint-plugin-react": "^4.1.0",
     "event-stream": "^3.3.2",

--- a/src/dev-tools.js
+++ b/src/dev-tools.js
@@ -3,15 +3,16 @@ import remote from 'remote';
 export default class DevTools {
   constructor() {
     this._open = false;
-    this._window = remote.getCurrentWindow();
   }
 
   toggle() {
     if (!this._open) {
-      this._window.openDevTools({detach: true});
+      const window = remote.getCurrentWindow();
+      window.openDevTools({detach: true});
       this._open = true;
     } else {
-      this._window.closeDevTools();
+      const window = remote.getCurrentWindow();
+      window.closeDevTools();
       this._open = false;
     }
   }


### PR DESCRIPTION
* Fix dev tools not opening (XFCE-only? Haven't seen this before): maybe due to Electron upgrade