### PR TITLE
Add auto updater

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "url": "https://github.com/james-proxy/james.git"
   },
   "dependencies": {
+    "electron-gh-releases": "^2.0.2",
     "hoxy": "^3.2.0",
     "james-browser-launcher": "^1.2.1",
     "materialize-css": "^0.97.5",

--- a/resource/updater.html
+++ b/resource/updater.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8">
+    <title>James Proxy</title>
+    <link href="./james.css" rel="stylesheet">
+</head>
+<body>
+    <div id="update">
+        <div class="spinner">
+            <div class="bounce-1"></div>
+            <div class="bounce-2"></div>
+            <div class="bounce-3"></div>
+        </div>
+        <div class="update-container">
+            <h2>New Version of James is available.</h2>
+            <h3>Would you like to download and install the update?</h3>
+            <div>
+                <button id="update-yes" class="btn waves-effect waves-light">Yes.</button>
+                <button id="update-no" class="btn waves-effect waves-light">No, remind me later.</button>
+            </div>
+        </div>
+    </div>
+    <script src="./updater.js"></script>
+</body>
+</html>

--- a/src/electron-app.js
+++ b/src/electron-app.js
@@ -1,36 +1,69 @@
-const electron = require('electron');
-const app = electron.app;  // Module to control application life.
-const ipc = electron.ipcMain;
-const BrowserWindow = require('browser-window');  // Module to create native browser window.
-const localShortcut = require('electron-localshortcut');
+import { app, ipcMain as ipc, BrowserWindow } from 'electron';
+import localShortcut from 'electron-localshortcut';
+import GithubReleases from 'electron-gh-releases';
 
-// Keep a global reference of the window object, if you don't, the window will
-// be closed automatically when the javascript object is GCed.
+const updater = new GithubReleases({
+  repo: 'james-proxy/james',
+  currentVersion: app.getVersion()
+});
+
 let mainWindow = null;
+let updateWindow = null;
 
-// Quit when all windows are closed.
 app.on('window-all-closed', () => app.quit());
 
-// This method will be called when Electron has done everything
-// initialization and ready for creating browser windows.
 app.on('ready', () => {
-  // Create the browser window.
   mainWindow = new BrowserWindow({
     width: 1024,
     height: 768,
     title: 'james'
   });
 
-  // and load the index.html of the app.
   mainWindow.loadURL('file://' + __dirname + '/index.html');
 
-  // Emitted when the window is closed.
   mainWindow.on('closed', function() {
-    // Dereference the window object, usually you would store windows
-    // in an array if your app supports multi windows, this is the time
-    // when you should delete the corresponding element.
     mainWindow = null;
   });
+
+  function showUpdateDialog() {
+    updateWindow = new BrowserWindow({
+      width: 512,
+      height: 192,
+      alwaysOnTop: true,
+      closable: false,
+      minimizable: false,
+      maximizable: false,
+      movable: false,
+      fullscreen: false,
+      resizable: false,
+      title: 'updater'
+    });
+
+    updateWindow.on('closed', function() {
+      updateWindow = null;
+    });
+
+    updateWindow.loadURL('file://' + __dirname + '/update.html');
+  }
+
+  updater.check((error, status) => {
+    if (!error && status) {
+      showUpdateDialog();
+    }
+  });
+});
+
+ipc.on('update-permitted', function(event, isPermitted) {
+  if (!isPermitted) {
+    return updateWindow.destroy();
+  }
+
+  updater.on('update-downloaded', () => {
+    updater.install();
+  });
+
+  mainWindow.close();
+  updater.download();
 });
 
 ipc.on('keyboard-listen', (event, {key}) => {

--- a/src/updater.js
+++ b/src/updater.js
@@ -1,0 +1,19 @@
+import ipc from 'ipc';
+
+function addUpdateListener(elementId, isUpdatePermitted) {
+  document.getElementById(elementId).addEventListener('click', () => {
+    document.getElementById('update').className = 'loading';
+    ipc.send('update-permitted', isUpdatePermitted);
+  });
+}
+
+const options = {
+  'update-yes': true,
+  'update-no': false
+};
+
+for (const option in options) {
+  if (options.hasOwnProperty(option)) {
+    addUpdateListener(option, options[option]);
+  }
+}

--- a/style/components/_spinner.scss
+++ b/style/components/_spinner.scss
@@ -1,0 +1,35 @@
+.spinner {
+  width: 70px;
+  height: 20px;
+  text-align: center;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  margin-left: -35px;
+  margin-top: -10px;
+}
+
+.spinner > div {
+  width: 18px;
+  height: 18px;
+  background-color: #26a69a;
+  border-radius: 100%;
+  display: inline-block;
+  animation: bounce-delay 1.4s infinite ease-in-out both;
+}
+
+.spinner .bounce-1 {
+  animation-delay: -0.32s;
+}
+
+.spinner .bounce-2 {
+  animation-delay: -0.16s;
+}
+
+@keyframes bounce-delay {
+  0%, 80%, 100% {
+    transform: scale(0);
+  } 40% {
+    transform: scale(1.0);
+  }
+}

--- a/style/components/windows/update.scss
+++ b/style/components/windows/update.scss
@@ -1,0 +1,40 @@
+#update {
+  padding: 15px;
+  background: $lightgray-light;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 100%;
+  text-align: center;
+
+  .btn + .btn {
+    margin-left: 5px;
+  }
+
+  h2 {
+    font-size: 24px;
+    color: $darkgray-light;
+    margin-top: 10px;
+    margin-bottom: 15px;
+  }
+
+  h3 {
+    font-size: 18px;
+    color: $darkgray-light;
+    margin-top: 0;
+    margin-bottom: 20px;
+  }
+
+  .spinner {
+    display: none;
+  }
+
+  &.loading {
+    .spinner {
+      display: block;
+    }
+    .update-container {
+      display: none;
+    }
+  }
+}

--- a/style/main.scss
+++ b/style/main.scss
@@ -10,7 +10,9 @@ $fa-font-path: "fonts" !default;
 @import 'components/requests';
 @import 'components/context-menu';
 @import 'components/inspect-request';
+@import 'components/spinner';
 @import 'components/windows/url-mapping';
+@import 'components/windows/update';
 
 @import url(http://fonts.googleapis.com/css?family=Lato:300,400,700);
 @import url(http://fonts.googleapis.com/css?family=Droid+Sans+Mono);


### PR DESCRIPTION
https://github.com/james-proxy/james/issues/139

The following needs to be resolved:
- [ ] Add and update `auto_updater.json` within travis release
- [ ] Disable in development environment

I added the module `electron-gh-releases`, which runs in the main process and will check for new releases on github. This check will be performed on startup and will only inform the user, when an update is available. Following window will appear: 

![bildschirmfoto 2016-04-01 um 16 20 19](https://cloud.githubusercontent.com/assets/4222309/14241730/534d55c6-fa4d-11e5-8e5c-526e6a4f6784.png)

If the user suspends the update, this window will be closed and pop up next startup. In case the user performs the update, the main window will be closed and the following loading screen will be shown:

![bildschirmfoto 2016-04-01 um 16 40 52](https://cloud.githubusercontent.com/assets/4222309/14241802/d5331b8e-fa4d-11e5-9c9c-22d0a32d9acd.png)

I'm not sure how to properly test the whole updater functionality, as we would need to actually release a new version of James. Also the `auto_updater.json` is currently missing in the repository. Any suggestions how to integrate the `auto_updater.json` updates nicely during the release on travis? What are your opinions?