### PR TITLE
Invalid version in prod builds

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,7 @@ const sourcemaps = require('gulp-sourcemaps');
 const autoprefixer = require('gulp-autoprefixer');
 const electron = require('electron-packager');
 const useref = require('gulp-useref');
-const electronConnect = require('electron-connect').server.create();
+const electronConnect = require('electron-connect').server;
 const gulpif = require('gulp-if');
 const browserify = require('browserify');
 const source = require('vinyl-source-stream');
@@ -44,6 +44,7 @@ gulp.task('css', () => {
 gulp.task('resources', () => {
   return es.merge([
     gulp.src('node_modules/font-awesome/fonts/**').pipe(gulp.dest('build/fonts')),
+    gulp.src('package.json').pipe(gulp.dest('build')),
     gulp.src('resource/**')
       .pipe(changed('build'))
       .pipe(gulp.dest('build'))
@@ -120,8 +121,10 @@ gulp.task('watch', ['default'], () => {
 });
 
 gulp.task('livereload', ['default'], () => {
-  electronConnect.start();
-  const reload = () => electronConnect.reload();
+  var server = electronConnect.create({path: './build'});
+  server.start();
+  const reload = () => server.reload();
+
   gulp.watch('src/**', ['js', reload]);
   gulp.watch('style/**', ['css', reload]);
   gulp.watch('resource/**', ['resources', reload]);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -54,6 +54,7 @@ gulp.task('package-resources', ['default'], () => {
   return es.merge([
     gulp.src('node_modules/font-awesome/fonts/**').pipe(gulp.dest('package/fonts')),
     gulp.src('build/james.css').pipe(gulp.dest('package')),
+    gulp.src('package.json').pipe(gulp.dest('package')),
     gulp.src('resource/**')
       .pipe(gulpif('*.html', useref()))
       .pipe(gulp.dest('package'))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -95,7 +95,9 @@ gulp.task('package-main', ['default'], () => {
 });
 
 gulp.task('package', ['package-resources', 'package-render', 'package-main'], (done) => {
+  const appVersion = require('./package.json').version;
   const electronVersion = require('electron-prebuilt/package.json').version;
+  console.log(`Packaging James v${appVersion}...`);
 
   electron({
     all: true,
@@ -104,6 +106,7 @@ gulp.task('package', ['package-resources', 'package-render', 'package-main'], (d
     name: 'James',
     overwrite: true,
     icon: 'resource/icon.icns',
+    'app-version': appVersion,
     version: electronVersion,
     out: 'binaries'
   }, (err) => done(err));

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "james",
   "version": "1.4.4",
   "description": "",
-  "main": "./electron-app.js",
+  "main": "electron-app.js",
   "scripts": {
     "build": "gulp",
     "watch": "gulp watch",
     "development": "gulp livereload",
     "package": "gulp clean package",
     "zip-binaries": "cd binaries; rm *.zip; for i in *; do zip --symlinks -r \"${i%/}.zip\" \"$i\"; done",
-    "start": "electron .",
+    "start": "electron ./build",
     "lint": "eslint ./src ./test",
     "test": "mocha --reporter dot --recursive -r setup-referee-sinon/globals test/unit --compilers js:babel-core/register",
     "test-ci": "npm run lint && npm run test && npm run package"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "james",
   "version": "1.4.4",
   "description": "",
-  "main": "./build/electron-app.js",
+  "main": "./electron-app.js",
   "scripts": {
     "build": "gulp",
     "watch": "gulp watch",

--- a/resource/package.json
+++ b/resource/package.json
@@ -1,3 +1,0 @@
-{
-  "main": "./electron-app.js"
-}

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,6 @@
+import remote from 'remote';
+const app = remote.require('app');
+
 export default {
   'PROXY_STATUS_WORKING': 'working',
   'PROXY_STATUS_NO_HTTPS': 'no_https',
@@ -5,5 +8,6 @@ export default {
   'PROXY_STATUS_ERROR_ADDRESS_IN_USE': 'error_address_in_use',
   'NEW_MAPPING_STEP_TARGET': 'target',
   'NEW_MAPPING_STEP_DESTINATION': 'destination',
-  'DEV': process.env.NODE_ENV !== 'production'
+  'DEV': process.env.NODE_ENV !== 'production',
+  'VERSION': app.getVersion()
 };

--- a/src/electron-app.js
+++ b/src/electron-app.js
@@ -1,8 +1,6 @@
-const electron = require('electron');
-const app = electron.app;  // Module to control application life.
-const ipc = electron.ipcMain;
-const BrowserWindow = require('browser-window');  // Module to create native browser window.
-const localShortcut = require('electron-localshortcut');
+import { app, ipcMain as ipc } from 'electron'; // app controls application life.
+import BrowserWindow from 'browser-window'; // Module to create native browser window.
+import localShortcut from 'electron-localshortcut';
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the javascript object is GCed.

--- a/src/service/raven.js
+++ b/src/service/raven.js
@@ -1,16 +1,14 @@
 import Raven from 'raven-js';
-import remote from 'remote';
+
 import config from '../config.js';
 import constants from '../constants.js';
-const app = remote.require('app');
 
 export default function init() {
   if (constants.DEV) {
     return;
   }
-  
+
   Raven.config('https://' + config.sentry.dsn + '@' + config.sentry.host, {
-    release: app.getVersion()
+    release: constants.VERSION
   }).install();
 }
-


### PR DESCRIPTION
Specify `app-version` property in `electron-packager` so that `app.getVersion()` returns the correct version.
Cleanup: constants, require/imports in electron-app.js
Fixes #173.