### PR TITLE
Don't insert __dirname as undefined in browserify

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -72,7 +72,6 @@ function gulpBrowserify(entry) {
       global: undefined,
       'Buffer.isBuffer': undefined,
       Buffer: undefined,
-      __dirname: undefined,
       __filename: undefined
     },
     ignoreMissing: true,


### PR DESCRIPTION
Fix #174