### PR TITLE
Fix electron deprecations

### DIFF
--- a/src/component/mapping/new-mapping-destination.js
+++ b/src/component/mapping/new-mapping-destination.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import remote from 'remote';
+import {remote} from 'electron';
 import createChooseFile from '../../service/choose-file.js';
 
 const {bool, string, func} = React.PropTypes;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,5 @@
-const {app} = require('electron').remote;
+import { remote } from 'electron';
+const { app } = remote;
 
 export default {
   'PROXY_STATUS_WORKING': 'working',

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,4 @@
-import remote from 'remote';
-const app = remote.require('app');
+const {app} = require('electron').remote;
 
 export default {
   'PROXY_STATUS_WORKING': 'working',
@@ -9,5 +8,5 @@ export default {
   'NEW_MAPPING_STEP_TARGET': 'target',
   'NEW_MAPPING_STEP_DESTINATION': 'destination',
   'DEV': process.env.NODE_ENV !== 'production',
-  'VERSION': app.getVersion()
+  'VERSION': '0.0.0'//app.getVersion()
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,5 +8,5 @@ export default {
   'NEW_MAPPING_STEP_TARGET': 'target',
   'NEW_MAPPING_STEP_DESTINATION': 'destination',
   'DEV': process.env.NODE_ENV !== 'production',
-  'VERSION': '0.0.0'//app.getVersion()
+  'VERSION': app.getVersion()
 };

--- a/src/dev-tools.js
+++ b/src/dev-tools.js
@@ -1,4 +1,4 @@
-import remote from 'remote';
+import {remote} from 'electron';
 
 export default class DevTools {
   constructor(startOpen) {

--- a/src/electron-app.js
+++ b/src/electron-app.js
@@ -28,8 +28,6 @@ app.on('ready', () => {
     // when you should delete the corresponding element.
     mainWindow = null;
   });
-
-  mainWindow.openDevTools();
 });
 
 ipc.on('keyboard-listen', (event, {key}) => {

--- a/src/electron-app.js
+++ b/src/electron-app.js
@@ -1,5 +1,4 @@
-import { app, ipcMain as ipc } from 'electron'; // app controls application life.
-import BrowserWindow from 'browser-window'; // Module to create native browser window.
+import { BrowserWindow, app, ipcMain as ipc } from 'electron'; // app controls application life.
 import localShortcut from 'electron-localshortcut';
 
 // Keep a global reference of the window object, if you don't, the window will
@@ -29,6 +28,8 @@ app.on('ready', () => {
     // when you should delete the corresponding element.
     mainWindow = null;
   });
+
+  mainWindow.openDevTools();
 });
 
 ipc.on('keyboard-listen', (event, {key}) => {

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ import DevTools from './dev-tools.js';
 import constants from './constants.js';
 
 import {remote} from 'electron';
-const {app, fs} = remote
+const {app, fs} = remote;
 
 ravenInit();
 createMenu();

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import hoxy from 'hoxy';
-import remote from 'remote';
 import Datastore from 'nedb';
 import browserLauncher from 'james-browser-launcher';
 
@@ -20,8 +19,8 @@ import DevTools from './dev-tools.js';
 
 import constants from './constants.js';
 
-const app = remote.require('app');
-const fs = remote.require('fs');
+import {remote} from 'electron';
+const {app, fs} = remote
 
 ravenInit();
 createMenu();

--- a/src/keyboard.js
+++ b/src/keyboard.js
@@ -1,13 +1,13 @@
-const ipc = require('electron').ipcRenderer;
+import { ipcRenderer } from 'electron';
 
 export default class Keyboard {
   constructor() {
     this.actions = {};
-    ipc.on('keyboard-press', (event, arg) => this.actions[arg]());
+    ipcRenderer.on('keyboard-press', (event, arg) => this.actions[arg]());
   }
 
   register(key, action) {
     this.actions[key] = action;
-    ipc.send('keyboard-listen', {key});
+    ipcRenderer.send('keyboard-listen', {key});
   }
 }

--- a/src/menu.js
+++ b/src/menu.js
@@ -1,7 +1,5 @@
-import remote from 'remote';
-import {shell} from 'electron';
-
-const Menu = remote.require('menu');
+import {shell, remote} from 'electron';
+const {Menu} = remote;
 
 function menuTempl() {
   const menu = [];

--- a/src/service/choose-file.js
+++ b/src/service/choose-file.js
@@ -1,7 +1,7 @@
-import remote from 'remote';
+import {remote} from 'electron';
 
 export default function createChooseFile(window) {
-  const dialog = remote.require('dialog');
+  const {dialog} = remote;
 
   return function chooseFile(callback) {
     dialog.showOpenDialog(window, {


### PR DESCRIPTION
Allegedly, [if you were on `v0.37.8`, you'd be notified of deprecated API usage](https://github.com/electron/electron/releases/tag/v1.0.0).
Welp, we didn't have any errors, but updating to electron `v1.0.0` wasn't a safe move. This fixes the broken bits