### PR TITLE
[WIP] Remove babel-preset-es2015

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   - os: osx
 language: node_js
 node_js:
-- '5.1'
+- '6.2'
 addons:
   apt:
     packages:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ cache:
   - '%USERPROFILE%\.electron'
 
 install:
-  - ps: Install-Product node 5 x64
+  - ps: Install-Product node 6.2 x64
   - npm install
   - npm prune
   - npm --depth Infinity update

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,8 +25,12 @@ gulp.task('js', (done) => {
   return gulp.src('src/**')
     .pipe(newer('build'))
     .pipe(babel({
-      presets: ['es2015', 'react'],
-      plugins: ['transform-object-rest-spread']
+      presets: ['react'],
+      plugins: [
+        "transform-object-rest-spread",
+        "transform-es2015-function-name",
+        "transform-es2015-modules-commonjs"
+    ]
     }))
     .on('error', done) // Handle error so 'watch' tasks don't stop mid-development, but still send errcode 1
     .pipe(gulp.dest('build'));

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "babel-core": "^6.4.5",
     "babel-eslint": "^6.0.0-beta.6",
     "babel-plugin-transform-object-rest-spread": "^6.3.13",
-    "babel-preset-es2015": "^6.3.13",
+    "babel-plugin-transform-es2015-function-name": "^6.3.13",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.6.0",
     "babel-preset-react": "^6.3.13",
     "browserify": "^13.0.0",
     "del": "^2.2.0",
@@ -73,11 +74,12 @@
   },
   "babel": {
     "presets": [
-      "react",
-      "es2015"
+      "react"
     ],
     "plugins": [
-      "transform-object-rest-spread"
+      "transform-object-rest-spread",
+      "transform-es2015-function-name",
+      "transform-es2015-modules-commonjs"
     ]
   },
   "build": {


### PR DESCRIPTION
**WIP**

Remove `babel-preset-es2015` to minimize the transforms babel needs to make.
Unnecessary now that Electron ships Chrome 50 which supports most of ES6, and we have no other targets to compile for. :tada:

I have a feeling that I should bump up the version Travis' node runs on as well...