### PR TITLE
Use electric-squirrel for electron 1.0.0+ support

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dist:win64": "build --platform win32 --arch x64"
   },
   "dependencies": {
-    "electron-squirrel-startup": "^0.1.4",
+    "electric-squirrel": "^1.0.0",
     "hoxy": "^3.2.0",
     "james-browser-launcher": "^1.2.1",
     "materialize-css": "^0.97.5",

--- a/src/electron-app.js
+++ b/src/electron-app.js
@@ -1,4 +1,4 @@
-import squirrelStartup from 'electron-squirrel-startup';
+import squirrelStartup from 'electric-squirrel';
 
 import { BrowserWindow, app, ipcMain as ipc } from 'electron'; // app controls application life.
 import localShortcut from 'electron-localshortcut';


### PR DESCRIPTION
I forgot that for #193 I had manually changed `electron-builder` to work with `electron@^1.0.0`. This will use a compatible fork, because [mongo doesn't want to merge a PR](https://github.com/mongodb-js/electron-squirrel-startup/pull/3)