### PR TITLE
Fix CSS watch

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,7 +34,7 @@ gulp.task('js', (done) => {
 
 gulp.task('css', () => {
   return gulp.src('style/main.scss')
-    .pipe(newer('build/james.css'))
+    .pipe(newer({dest: 'build/james.css', extra: ['style/**/*.scss']}))
     .pipe(sourcemaps.init())
     .pipe(sass({outputStyle: 'compressed'}).on('error', sass.logError))
     .pipe(rename('james.css'))
@@ -42,7 +42,7 @@ gulp.task('css', () => {
     .pipe(gulp.dest('build'));
 });
 
-// There's two separate `resource-*` directories. 
+// There's two separate `resource-*` directories.
 // `resource-runtime` contains actual files which will exist in the same
 // directory as James at runtime, in production (e.g. the browser images).
 // `resource-compile` has resources that we don't necessarily want taking space with James, because they're compiled

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "gulp-babel": "^6.1.1",
     "gulp-if": "^2.0.0",
     "gulp-json-editor": "^2.2.1",
-    "gulp-newer": "^1.1.0",
+    "gulp-newer": "^1.2.0",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.1.1",
     "gulp-sourcemaps": "^1.6.0",


### PR DESCRIPTION
Most likely a #205 regression. Not really sure why this is no longer working, or maybe I didn't test this thoroughly enough originally.

Reproduce by changing the logo background-color in `_titlebar.scss` for complete obviousness.

Not completely convinced this is the right solution either, as it results in the following error during watch:

> Error in plugin 'sass'
Message:
    style\components\_browser.scss
Error: Undefined variable: "$mediumgray-light".
        on line 10 of style/components/_browser.scss
     border: 1px solid $mediumgray-light;
   ----------------------^

Which I know for sure is defined, in `_colors.scss`, so that leads me to think things aren't getting imported in the right order, or possibly everything's getting extra imported? Haven't looked closely enough there, as this solution seems wrong. Either that, or the current way of how we're doing sass is wrong (lack of imports except in main). Not 100% sure.

I figured an alternative solution would be:
```
  return gulp.src('style/main.scss')
    .pipe(newer({dest: 'build/james.css', extra: ['style/main.scss', 'style/**/*.scss']}))
```
but that's not working for me.