### PR TITLE
Fix HTTPS not working

### DIFF
--- a/src/component/footer/proxy-status.js
+++ b/src/component/footer/proxy-status.js
@@ -23,16 +23,17 @@ const getMessage = (status) => {
   return messageMap[status];
 };
 
-const ProxyStatus = ({proxyStatus, proxyWindow}) => {
+const ProxyStatus = ({proxyStatus, proxyReason, proxyWindow}) => {
   const icon = 'fa ' + iconMap[proxyStatus];
   const message = 'Proxy: ' + getMessage(proxyStatus);
+  const title = proxyReason;
   const classes = ['proxy-status', proxyStatus];
 
   if (proxyWindow) {
     classes.push('with-info');
   }
 
-  return <div className={classes.join(' ')} title={message} onClick={proxyWindow}>
+  return <div className={classes.join(' ')} title={title} onClick={proxyWindow}>
     <i className={icon} />
     <span className="message">{message}</span>
   </div>;
@@ -45,6 +46,7 @@ ProxyStatus.propTypes = {
     constants.PROXY_STATUS_ERROR_ADDRESS_IN_USE,
     constants.PROXY_STATUS_ERROR_GENERIC
   ]).isRequired,
+  proxyReason: string,
   proxyWindow: func,
   proxyMessage: string
 };

--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ const createHoxy = () => {
     const cert = fs.readFileSync('./root-ca.crt.pem');
     opts.certAuthority = {key, cert};
   } catch (e) {
-    data.proxyReason = e.message;
+    data.proxyReason = e.message.split('\n')[0];
     data.proxyStatus = constants.PROXY_STATUS_NO_HTTPS;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,8 @@ import DevTools from './dev-tools.js';
 import constants from './constants.js';
 
 import {remote} from 'electron';
-const {app, fs} = remote;
+const {app} = remote;
+const fs = remote.require('fs');
 
 ravenInit();
 createMenu();
@@ -42,6 +43,7 @@ const data = {
   cachingEnabled: false,
   throttle: {enabled: false, rate: 0}, // rate is in kBps
   proxyStatus: 'working',
+  proxyReason: undefined,
   proxyWindow: undefined
 };
 
@@ -59,6 +61,7 @@ const createHoxy = () => {
     const cert = fs.readFileSync('./root-ca.crt.pem');
     opts.certAuthority = {key, cert};
   } catch (e) {
+    data.proxyReason = e.message;
     data.proxyStatus = constants.PROXY_STATUS_NO_HTTPS;
   }
 
@@ -192,6 +195,7 @@ function render() {
         toggleThrottle={toggleThrottle}
         onRateChange={throttleRateChange}
         proxyStatus={data.proxyStatus}
+        proxyReason={data.proxyReason}
         proxyWindow={data.proxyWindow}
         enabled={enabled}
         rate={rate} />


### PR DESCRIPTION
Electron still does remote.require() for 'fs', apparently
Change proxy tooltip to show reason

Fix #221 