### PR TITLE
Greenkeeper electron prebuilt 1.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "electron-builder": "^5.0.2",
     "electron-connect": "^0.4.0",
     "electron-localshortcut": "^0.6.0",
-    "electron-prebuilt": "1.2.2",
+    "electron-prebuilt": "1.2.3",
     "envify": "^3.4.0",
     "eslint": "^2.2.0",
     "eslint-plugin-react": "^5.0.1",

--- a/src/electron-app.js
+++ b/src/electron-app.js
@@ -19,8 +19,7 @@ app.on('ready', () => {
   // Create the browser window.
   mainWindow = new BrowserWindow({
     width: 1024,
-    height: 768,
-    title: 'james'
+    height: 768
   });
 
   // and load the index.html of the app.


### PR DESCRIPTION
Update electron to `1.2.3`, remove now-redundant options