### PR TITLE
Updates Raven to use credentials for new Sentry host

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -5,7 +5,7 @@ export default {
 
   ],
   sentry: {
-    dsn: 'efe270d1329547fa9856935a2c535cba',
-    host: 'sentry.fuzzlesoft.ca/6'
+    dsn: '617ec0238f4a44ac97b9953b2ee0b67c',
+    host: 'sentry.fuzzlesoft.ca/4'
   }
 };


### PR DESCRIPTION
I'm migrating services from Sweden to local servers in Canada, and Sentry can't really "export" organizations or projects. So, I created a new one on a new Sentry instance, and this will attach James to it