### PR TITLE
Use latest version (1.3.0) of james-browser-launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "electron-squirrel-startup": "^1.0.0",
     "hoxy": "^3.2.0",
-    "james-browser-launcher": "^1.2.1",
+    "james-browser-launcher": "^1.3.0",
     "lodash.throttle": "^4.1.0",
     "materialize-css": "^0.97.5",
     "nedb": "^1.7.1",


### PR DESCRIPTION
Hey guys,

I saw some fixes being implemented on `james-browser-launcher`.
Here's a small PR to set the correct version number.

One other thing:
What do you think about fixating all the dependencies?