### PR TITLE
Display hint about automatic proxy setup

### DIFF
--- a/src/containers/home.js
+++ b/src/containers/home.js
@@ -9,6 +9,11 @@ const HomeContainer = ({port}) =>
       <h2>Proxy started on localhost:{port}</h2>
       <h3>Launch a browser, using James as a proxy</h3>
       <Browsers />
+      <p className="hint-text">
+        <i className="fa fa-info-circle" />
+        In some browsers the automatic proxy setup does not work correctly.
+        In that case you have to do it manually.
+        </p>
     </div>
   </div>;
 

--- a/style/components/main-content.scss
+++ b/style/components/main-content.scss
@@ -55,5 +55,10 @@
       font-size: 18px;
       margin: 0;
     }
+
+    .hint-text {
+      margin-bottom: 0;
+      text-align: left;
+    }
   }
 }


### PR DESCRIPTION
As [mentioned here](https://github.com/james-proxy/james/pull/331#issuecomment-306141337) for some browsers it's not possible to setup the proxy settings manually. So we should show a hint so the user is not completely lost.

![screenshot from 2017-06-05 12-17-54](https://cloud.githubusercontent.com/assets/423218/26780221/09aa2916-49e9-11e7-8e0a-162bc79f2692.png)

