### PR TITLE
Update gulp-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,11 +65,10 @@
     "gulp-json-editor": "^2.2.1",
     "gulp-newer": "^1.2.0",
     "gulp-rename": "^1.2.2",
-    "gulp-sass": "^2.1.1",
+    "gulp-sass": "^3.1.0",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-useref": "^3.0.5",
     "mocha": "^3.0.1",
-    "node-sass": "3.10.1",
     "redux-mock-store": "^1.0.4",
     "referee": "^1.2.0",
     "referee-sinon": "^1.0.3",
@@ -103,7 +102,10 @@
       "iconUrl": "https://github.com/mitchhentges/james/blob/electron-builder/resource-compile/icon.ico?raw=true"
     },
     "linux": {
-      "target": ["AppImage", "deb"],
+      "target": [
+        "AppImage",
+        "deb"
+      ],
       "synopsis": "Web proxy"
     }
   },


### PR DESCRIPTION
The super-out-of-date `gulp-sass` that we were using doesn't work on Linux with NodeJS 8.

Soon we're going to need to change from `gulp-sass` (now unmaintained) to `node-sass` with a wrapper (does gulp's `vinyl` cover that?)