### PR TITLE
Lock webpack-sources to version 1.0.1 to avoid build failure on NPM 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "sass-loader": "^6.0.6",
     "sinon": "^4.1.3",
     "webpack": "^3.10.0",
-    "webpack-sources": "^1.0.1"
+    "webpack-sources": "1.0.1"
   },
   "electronWebpack": {
     "title": "James Proxy",


### PR DESCRIPTION
Newer `webpack-sources` throws the following error:

> Error: original.line and original.column are not numbers -- you probably meant to omit the original mapping entirely and only map the generated position. If so, pass null for the original mapping instead of an object with empty or null values.

Since npm3 doesn't use the `package-lock.json`, we need to lock `webpack-sources@1.0.1` to avoid the issue