### PR TITLE
MappingCount component.

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -48,7 +48,7 @@ Raven.context(() => {
     }
     mainWindow.loadURL(rendererURL);
     if (constants.DEV) {
-      mainWindow.webContents.openDevTools();
+      mainWindow.webContents.openDevTools({mode: 'detach'});
     }
 
     mainWindow.webContents.on('did-finish-load', () => {

--- a/src/renderer/component/title-bar/mapping-count.js
+++ b/src/renderer/component/title-bar/mapping-count.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+const MappingCount = ({ urlMapCount }) => {
+  if (!urlMapCount) return null;
+  return <span className="label default">
+    {urlMapCount}
+  </span>;
+};
+
+MappingCount.propTypes = {
+  urlMapCount: PropTypes.number.isRequired
+};
+
+import { getMappingCount } from '../../reducers/url-mappings.js';
+
+const mapStateToProps = (state) => ({
+  urlMapCount: getMappingCount(state)
+});
+
+export default connect(mapStateToProps)(MappingCount);

--- a/src/renderer/component/title-bar/title-bar.js
+++ b/src/renderer/component/title-bar/title-bar.js
@@ -1,19 +1,12 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { NavLink } from 'react-router-dom';
 
 import { toggleDevTools } from 'common/service/dev-tools.js';
 
-const TitleBar = ({ urlMapCount }) => {
-  let UrlMapCountLabel;
-  if (urlMapCount > 0) {
-    UrlMapCountLabel = <span className="label default">
-      {urlMapCount}
-    </span>;
-  }
+import MappingCount from './mapping-count.js';
 
-  return <div className="titlebar">
+export default () =>
+  <div className="titlebar">
     <span className="logo">
       J
     </span>
@@ -27,24 +20,10 @@ const TitleBar = ({ urlMapCount }) => {
     <NavLink to="/url-mappings" exact activeClassName="active">
       <i className="fa fa-plug" />
       Mappings
-      {UrlMapCountLabel}
+      <MappingCount />
     </NavLink>
     <a className="right" onClick={toggleDevTools}>
       <i className=" fa fa-cog" />
       Developer
     </a>
   </div>;
-};
-
-TitleBar.propTypes = {
-  urlMapCount: PropTypes.number.isRequired
-};
-
-import { getMappingCount } from '../../reducers/url-mappings.js';
-
-const mapStateToProps = (state) => ({
-  active: state.routing, // trigger connect to update component on routing change
-  urlMapCount: getMappingCount(state)
-});
-
-export default connect(mapStateToProps)(TitleBar);

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -9,7 +9,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { ConnectedRouter as Router } from 'react-router-redux';
-import createHistory from 'history/createBrowserHistory';
+import createHistory from 'history/createHashHistory';
 import throttle from 'lodash.throttle';
 import Raven from 'raven-js';
 


### PR DESCRIPTION
- Split off MappingCount into it's own component - this avoids the `connect` optimization shenanigans that interfere with `react-router`. Fixes #348.
- Change devTools back to open as detached on dev start.
- Switches to hash history (`/#/requests`) to avoid issues with HMR.