### PR TITLE
Fix Windows auto-update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -335,14 +335,14 @@
       }
     },
     "app-package-builder": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/app-package-builder/-/app-package-builder-2.0.0.tgz",
-      "integrity": "sha512-muqpe1PiCIdWGjf4dBtl632o1ZTMqnKl/2nt0S4J5EpV39ZXwdNEI8I6RpBhHrCoZsDf30Gr8F0+j5pjNkVb0Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/app-package-builder/-/app-package-builder-3.0.0.tgz",
+      "integrity": "sha512-w9OO61nbocUeNlJh6FEkByOs+Oll++tEwyZt3mZoOLK0QeG7Xnqzo8fft+yVByRB9qLILEZKFUsvtyas8kIkew==",
       "dev": true,
       "requires": {
         "bluebird-lst": "1.0.5",
-        "builder-util": "3.4.4",
-        "builder-util-runtime": "3.4.0",
+        "builder-util": "3.4.5",
+        "builder-util-runtime": "3.4.1",
         "fs-extra-p": "4.5.0",
         "int64-buffer": "0.1.10",
         "rabin-bindings": "1.7.4"
@@ -725,15 +725,17 @@
       }
     },
     "babel-eslint": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.0.3.tgz",
-      "integrity": "sha512-7D4iUpylEiKJPGbeSAlNddGcmA41PadgZ6UAb6JVyh003h3d0EbZusYFBR/+nBgqtaVJM2J2zUVa3N0hrpMH6g==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.1.2.tgz",
+      "integrity": "sha512-IE+glF8t0lLoldylN7JyR8gT7e3jwyuNH2ds8g3UVUwGob/U4iT7Xpsiq2kQ8QGLb0eX4RcQXNqeW6mgPysu9A==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0-beta.31",
         "@babel/traverse": "7.0.0-beta.31",
         "@babel/types": "7.0.0-beta.31",
-        "babylon": "7.0.0-beta.31"
+        "babylon": "7.0.0-beta.31",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "1.0.0"
       },
       "dependencies": {
         "babylon": {
@@ -3086,14 +3088,14 @@
       "dev": true
     },
     "builder-util": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-3.4.4.tgz",
-      "integrity": "sha512-TFtm1yzFd3x34dR5dIs8hxAaDvH08ZiEY3QGvwI2lo+UZos+AIeQ4q/pxPU7lBZ+BMNWzVymG/LZcNu6N3g+vQ==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-3.4.5.tgz",
+      "integrity": "sha512-y47p/OCfq74QrpIeJRHRz+rGeLj+EVczSIhwyiS5h9MKCYdtiwjDBMSrLlEvg0/rrxG5i1kwG9W9pX+Yccz2qg==",
       "dev": true,
       "requires": {
         "7zip-bin": "2.3.4",
         "bluebird-lst": "1.0.5",
-        "builder-util-runtime": "3.4.0",
+        "builder-util-runtime": "3.4.1",
         "chalk": "2.3.0",
         "debug": "3.1.0",
         "fs-extra-p": "4.5.0",
@@ -3157,9 +3159,9 @@
       }
     },
     "builder-util-runtime": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-3.4.0.tgz",
-      "integrity": "sha512-/i1n4hpanG7g2ikuc772Rza1zqKCMstGurdb9S9e1q+Q8Xenba8EbmN+Qqy/8PvhkL8T09SiMn9Yf+mb/8ACbQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-3.4.1.tgz",
+      "integrity": "sha512-I5fvn41z+vdjPvDZD6RigjyGyWQqjAh8Rs2IVbCI7HXlnEHkyT6Sl5fsS85eAjzs+huLzdbyABHz2CxGviPfWg==",
       "dev": true,
       "requires": {
         "bluebird-lst": "1.0.5",
@@ -4267,15 +4269,15 @@
       }
     },
     "dmg-builder": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-2.1.8.tgz",
-      "integrity": "sha512-fcdvE+Af1nGb0vB5+eDjC2+FWXAjsgpS7HAuM1Gk3wIUQTIv2n503+akKnA2be/5kGlqyJ4zjfo/Lk1f+G/new==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-2.1.9.tgz",
+      "integrity": "sha512-PFt5VWLl+D+8VhnJAJFqMGkXIkn6VnRXnnFfN8UZV9Gcn0I0dArV7ENJEK+kUPpFpWm04LbjJBCkqvy/MhcmsQ==",
       "dev": true,
       "requires": {
         "bluebird-lst": "1.0.5",
-        "builder-util": "3.4.4",
+        "builder-util": "3.4.5",
         "debug": "3.1.0",
-        "fs-extra-p": "4.4.4",
+        "fs-extra-p": "4.5.0",
         "iconv-lite": "0.4.19",
         "js-yaml": "3.10.0",
         "parse-color": "1.0.0"
@@ -4288,6 +4290,36 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
+          }
+        },
+        "fs-extra-p": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-4.5.0.tgz",
+          "integrity": "sha512-V/sdZmV+Yx3+nfXmjRTdBP4mVWCt7hZ0+ZOv+IZo+6fdkBxafaGsI7mYeNv/J3rWyz+mIToCFQORFSwt1bZw8Q==",
+          "dev": true,
+          "requires": {
+            "bluebird-lst": "1.0.5",
+            "fs-extra": "5.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
           }
         }
       }
@@ -4456,21 +4488,21 @@
       }
     },
     "electron-builder": {
-      "version": "19.49.0",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-19.49.0.tgz",
-      "integrity": "sha512-Fh3VMgn1khw6189Q5lUJ4LC7T4ADAl+R7pYBzyhB4jXRPZ0Qfm8QMKQGm92ZM8f2xMAJO63FfV9nkWovMNhoDA==",
+      "version": "19.49.4",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-19.49.4.tgz",
+      "integrity": "sha512-T/1kDil89WogSd06VlDpoQCQxrFC/knTgX9wYXjEJuLXSrgi9uYe5x4xS0KUWWDlipjZDJs/hvL3u0fKwDrh5g==",
       "dev": true,
       "requires": {
         "bluebird-lst": "1.0.5",
-        "builder-util": "3.4.4",
-        "builder-util-runtime": "3.4.0",
+        "builder-util": "3.4.5",
+        "builder-util-runtime": "3.4.1",
         "chalk": "2.3.0",
-        "electron-builder-lib": "19.49.0",
+        "electron-builder-lib": "19.49.4",
         "electron-download-tf": "4.3.4",
         "fs-extra-p": "4.5.0",
         "is-ci": "1.0.10",
         "lazy-val": "1.0.3",
-        "read-config-file": "1.2.1",
+        "read-config-file": "1.2.2",
         "sanitize-filename": "1.6.1",
         "update-notifier": "2.3.0",
         "yargs": "10.0.3"
@@ -4579,9 +4611,9 @@
           "dev": true
         },
         "read-config-file": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-1.2.1.tgz",
-          "integrity": "sha512-XbBZIKDFknS5pV2ddMTTfdwMEIUhUS6io1PYB35E4i7d7RwYrKQ2ix9EfzrN7UK/b3sispCXhlWTLdJnVCFuMw==",
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-1.2.2.tgz",
+          "integrity": "sha512-Q6bxc6mm2ZalO0PWgUelfo0Fp91/EKtA1yL4apvzCzK9krhftr9vOq1td9vU1nxpadMjfnudv4Ye/WXm4IWTWQ==",
           "dev": true,
           "requires": {
             "ajv": "5.5.2",
@@ -4638,21 +4670,21 @@
       }
     },
     "electron-builder-lib": {
-      "version": "19.49.0",
-      "resolved": "https://registry.npmjs.org/electron-builder-lib/-/electron-builder-lib-19.49.0.tgz",
-      "integrity": "sha512-nrL27T7MfbsNgCkgw/ewm/Uw1TY7VgU8r2z64x2mSvJw5geNnRto8k23IlMN0OKeOf9e3C6mMfe7hTGExRfZcg==",
+      "version": "19.49.4",
+      "resolved": "https://registry.npmjs.org/electron-builder-lib/-/electron-builder-lib-19.49.4.tgz",
+      "integrity": "sha512-iTjuD+BtmVaAyUlFaGH3pG63kK1iGi5qcBh3ZYw6HYAeTNrRePPHkGEQiNyGAqCFq63S+ShEk3Iy58htlt57hQ==",
       "dev": true,
       "requires": {
         "7zip-bin": "2.3.4",
-        "app-package-builder": "2.0.0",
+        "app-package-builder": "3.0.0",
         "asar-integrity": "0.2.3",
         "async-exit-hook": "2.0.1",
         "bluebird-lst": "1.0.5",
-        "builder-util": "3.4.4",
-        "builder-util-runtime": "3.4.0",
+        "builder-util": "3.4.5",
+        "builder-util-runtime": "3.4.1",
         "chromium-pickle-js": "0.2.0",
         "debug": "3.1.0",
-        "dmg-builder": "2.1.8",
+        "dmg-builder": "2.1.9",
         "ejs": "2.5.7",
         "electron-osx-sign": "0.4.7",
         "electron-publish": "19.49.0",
@@ -4665,7 +4697,7 @@
         "minimatch": "3.0.4",
         "normalize-package-data": "2.4.0",
         "plist": "2.1.0",
-        "read-config-file": "1.2.1",
+        "read-config-file": "1.2.2",
         "sanitize-filename": "1.6.1",
         "semver": "5.4.1",
         "temp-file": "3.0.0"
@@ -4729,9 +4761,9 @@
           "dev": true
         },
         "read-config-file": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-1.2.1.tgz",
-          "integrity": "sha512-XbBZIKDFknS5pV2ddMTTfdwMEIUhUS6io1PYB35E4i7d7RwYrKQ2ix9EfzrN7UK/b3sispCXhlWTLdJnVCFuMw==",
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-1.2.2.tgz",
+          "integrity": "sha512-Q6bxc6mm2ZalO0PWgUelfo0Fp91/EKtA1yL4apvzCzK9krhftr9vOq1td9vU1nxpadMjfnudv4Ye/WXm4IWTWQ==",
           "dev": true,
           "requires": {
             "ajv": "5.5.2",
@@ -4826,11 +4858,11 @@
       "dev": true,
       "requires": {
         "bluebird-lst": "1.0.5",
-        "builder-util": "3.4.4",
-        "builder-util-runtime": "3.4.0",
+        "builder-util": "3.4.5",
+        "builder-util-runtime": "3.4.1",
         "chalk": "2.3.0",
         "fs-extra-p": "4.5.0",
-        "mime": "2.0.3"
+        "mime": "2.1.0"
       },
       "dependencies": {
         "fs-extra": {
@@ -4864,9 +4896,9 @@
           }
         },
         "mime": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.0.3.tgz",
-          "integrity": "sha512-TrpAd/vX3xaLPDgVRm6JkZwLR0KHfukMdU2wTEbqMDdCnY6Yo3mE+mjs9YE6oMNw2QRfXVeBEYpmpO94BIqiug==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.1.0.tgz",
+          "integrity": "sha512-jPEuocEVyg24I7hWcF6EL5qH0OQ3Ficy95tXA9eNBN6qXsIopYi/CJl3ldTUR+Sljt2rP2SkWpeTcAMon/pjKA==",
           "dev": true
         }
       }
@@ -4878,30 +4910,41 @@
       "dev": true
     },
     "electron-updater": {
-      "version": "2.17.6",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-2.17.6.tgz",
-      "integrity": "sha512-2xU544Ha0OXSMhypC4+EMfD+8rUH47OQ3UYGXJJjIaQNdIVF17EDoftsgoTAbL3N4axaPYBCPOiuEowyvFzNlw==",
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-2.16.3.tgz",
+      "integrity": "sha512-CuzODrj8PqzOoJummHkC1hzrM/Z01gio6G2Z9/LxhcrMfKfwlfs3jl4ds0ryDeoPnQafCK9tT1brDjW7rSYd9w==",
       "requires": {
         "bluebird-lst": "1.0.5",
-        "builder-util-runtime": "3.4.1",
+        "builder-util-runtime": "3.3.1",
         "electron-is-dev": "0.3.0",
-        "fs-extra-p": "4.5.0",
+        "fs-extra-p": "4.4.4",
         "js-yaml": "3.10.0",
-        "lazy-val": "1.0.3",
+        "lazy-val": "1.0.2",
         "lodash.isequal": "4.5.0",
         "semver": "5.4.1",
         "source-map-support": "0.5.0"
       },
       "dependencies": {
         "builder-util-runtime": {
-          "version": "3.4.1",
-          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-3.4.1.tgz",
-          "integrity": "sha512-I5fvn41z+vdjPvDZD6RigjyGyWQqjAh8Rs2IVbCI7HXlnEHkyT6Sl5fsS85eAjzs+huLzdbyABHz2CxGviPfWg==",
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-3.3.1.tgz",
+          "integrity": "sha512-Z7ofwcr0PBptBtCl07prJg8yJxPgY2Zo4NiPYLSAsbE8Q9qMm+51274G17hE55w/eRYdprV5+bRGW/tyMfE4Lw==",
           "requires": {
             "bluebird-lst": "1.0.5",
             "debug": "3.1.0",
             "fs-extra-p": "4.5.0",
             "sax": "1.2.4"
+          },
+          "dependencies": {
+            "fs-extra-p": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-4.5.0.tgz",
+              "integrity": "sha512-V/sdZmV+Yx3+nfXmjRTdBP4mVWCt7hZ0+ZOv+IZo+6fdkBxafaGsI7mYeNv/J3rWyz+mIToCFQORFSwt1bZw8Q==",
+              "requires": {
+                "bluebird-lst": "1.0.5",
+                "fs-extra": "5.0.0"
+              }
+            }
           }
         },
         "debug": {
@@ -4922,15 +4965,6 @@
             "universalify": "0.1.1"
           }
         },
-        "fs-extra-p": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-4.5.0.tgz",
-          "integrity": "sha512-V/sdZmV+Yx3+nfXmjRTdBP4mVWCt7hZ0+ZOv+IZo+6fdkBxafaGsI7mYeNv/J3rWyz+mIToCFQORFSwt1bZw8Q==",
-          "requires": {
-            "bluebird-lst": "1.0.5",
-            "fs-extra": "5.0.0"
-          }
-        },
         "jsonfile": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -4938,11 +4972,6 @@
           "requires": {
             "graceful-fs": "4.1.11"
           }
-        },
-        "lazy-val": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.3.tgz",
-          "integrity": "sha512-pjCf3BYk+uv3ZcPzEVM0BFvO9Uw58TmlrU0oG5tTrr9Kcid3+kdKxapH8CjdYmVa2nO5wOoZn2rdvZx2PKj/xg=="
         }
       }
     },
@@ -5330,9 +5359,9 @@
       }
     },
     "eslint": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.13.1.tgz",
-      "integrity": "sha512-UCJVV50RtLHYzBp1DZ8CMPtRSg4iVZvjgO9IJHIKyWU/AnJVjtdRikoUPLB29n5pzMB7TnsLQWf0V6VUJfoPfw==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.14.0.tgz",
+      "integrity": "sha512-Ul6CSGRjKscEyg0X/EeNs7o2XdnbTEOD1OM8cTjmx85RPcBJQrEhZLevhuJZNAE/vS2iVl5Uhgiqf3h5uLMCJQ==",
       "dev": true,
       "requires": {
         "ajv": "5.5.0",
@@ -5343,9 +5372,9 @@
         "debug": "3.1.0",
         "doctrine": "2.0.2",
         "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "1.0.0",
         "espree": "3.5.2",
         "esquery": "1.0.0",
-        "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
@@ -5419,6 +5448,12 @@
         "estraverse": "4.2.0"
       }
     },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
     "esmangle-evaluator": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.1.tgz",
@@ -5450,14 +5485,14 @@
       "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.2.1",
+        "acorn": "5.3.0",
         "acorn-jsx": "3.0.1"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
+          "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
           "dev": true
         }
       }
@@ -6031,7 +6066,6 @@
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-4.4.4.tgz",
       "integrity": "sha512-zHsMNJWhXD184QfHKEIFSQSgAFNV7v9J+Nt2XpaLZp2nTz6WxZNV+R4G2uYeGeLTMaKvUZiqGKrH/4iFCupcUA==",
-      "dev": true,
       "requires": {
         "bluebird-lst": "1.0.5",
         "fs-extra": "4.0.2"
@@ -6041,7 +6075,6 @@
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
           "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "jsonfile": "4.0.0",
@@ -6052,7 +6085,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11"
           }
@@ -6444,8 +6476,7 @@
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "json-schema": {
           "version": "0.2.3",
@@ -8267,8 +8298,7 @@
     "lazy-val": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.2.tgz",
-      "integrity": "sha512-2BaSu6qVnicKdWQPysrffZVFAKcPcZQ/q2YyeSjAxWaJlvCvKSrkcvsSHlleeIfA//fW2goTcYDTy2cBLN7+PQ==",
-      "dev": true
+      "integrity": "sha512-2BaSu6qVnicKdWQPysrffZVFAKcPcZQ/q2YyeSjAxWaJlvCvKSrkcvsSHlleeIfA//fW2goTcYDTy2cBLN7+PQ=="
     },
     "lcid": {
       "version": "1.0.0",
@@ -8877,9 +8907,9 @@
       }
     },
     "mocha": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
-      "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dist:win64": "build --windows --x64"
   },
   "dependencies": {
-    "electron-updater": "^2.17.6",
+    "electron-updater": "2.16.3",
     "font-awesome": "^4.5.0",
     "history": "^4.7.2",
     "hoxy": "^3.2.0",
@@ -51,17 +51,17 @@
     "uniqid": "^4.0.0"
   },
   "devDependencies": {
-    "babel-eslint": "^8.0.3",
+    "babel-eslint": "^8.1.2",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-power-assert": "^1.0.0",
     "babel-preset-react": "^6.24.1",
     "electron": "^1.7.10",
-    "electron-builder": "^19.49.0",
+    "electron-builder": "^19.49.4",
     "electron-localshortcut": "^2.0.2",
     "electron-webpack": "^1.11.0",
-    "eslint": "^4.13.1",
+    "eslint": "^4.14.0",
     "eslint-plugin-react": "^7.5.1",
-    "mocha": "^4.0.1",
+    "mocha": "^4.1.0",
     "mocha-webpack": "^1.0.1",
     "node-sass": "4.7.2",
     "power-assert": "^1.4.4",


### PR DESCRIPTION
- Downgrade `electron-updater` to `2.16.3` to fix the auto-update issue on Windows.
- Update other dependencies.

`electron-updater 2.17.x` seems to have issues with auto-update on Windows. There's been a handful of issues reported about the same symptoms I mentioned in #355 where an update is available, logs that it's downloading, but it never actually downloads or even errors.

I was able to test this by changing my package version to `2.0.0-beta.1`, running `npm run dist`, and installing the newly built package, which then checked GitHub releases for the beta.2 release and successfully downloaded it.

Still have an issue with restart to install, will figure something out in a different PR. It quit without relaunching, but at least we did manage to update to beta.2 without cert errors.