### PR TITLE
Uses relative imports

### DIFF
--- a/src/common/actions/browsers.js
+++ b/src/common/actions/browsers.js
@@ -1,4 +1,4 @@
-import openBrowser from 'common/service/open-browser.js';
+import openBrowser from '../service/open-browser.js';
 import { navigateToRequests } from './app.js';
 
 export const ADD_BROWSERS = 'ADD_BROWSERS';

--- a/src/common/actions/proxy.js
+++ b/src/common/actions/proxy.js
@@ -1,4 +1,4 @@
-import constants from 'common/constants.js';
+import constants from '../constants.js';
 
 export const TOGGLE_CACHING = 'TOGGLE_CACHING';
 export const TOGGLE_THROTTLING = 'TOGGLE_THROTTLING';

--- a/src/common/actions/url-mappings.js
+++ b/src/common/actions/url-mappings.js
@@ -1,6 +1,6 @@
 import { navigateToUrlMappings } from './app.js';
 
-import constants from 'common/constants.js';
+import constants from '../constants.js';
 
 export const SET_URL_MAPPING = 'SET_URL_MAPPING';
 export const UPDATE_URL_MAPPING = 'UPDATE_URL_MAPPING';

--- a/src/common/service/shortcuts.js
+++ b/src/common/service/shortcuts.js
@@ -1,7 +1,7 @@
 import Keyboard from './keyboard.js';
 
 import { toggleDevTools } from './dev-tools.js';
-import { showAddUrlMapping } from 'common/actions/url-mappings.js';
+import { showAddUrlMapping } from '../actions/url-mappings.js';
 
 export default (store) => {
   const keyboard = new Keyboard();

--- a/src/main/auto-update.js
+++ b/src/main/auto-update.js
@@ -1,7 +1,7 @@
 import { autoUpdater } from 'electron-updater';
 import * as Sentry from '@sentry/node';
 
-import constants from 'common/constants.js';
+import constants from '../common/constants.js';
 
 autoUpdater.autoDownload = true;
 
@@ -24,23 +24,23 @@ export default (win, enabled) => {
   autoUpdater.on('checking-for-update', () => {
     updateStatus(constants.UPDATE_CHECKING);
   });
-  
+
   autoUpdater.on('update-available', (info) => {
     updateStatus(constants.UPDATE_AVAILABLE, info);
   });
-  
+
   autoUpdater.on('update-not-available', (info) => {
     updateStatus(constants.UPDATE_OK, info);
   });
-  
+
   autoUpdater.on('download-progress', (progress) => {
     updateStatus(constants.UPDATE_DOWNLOADING, progress);
   });
-  
+
   autoUpdater.on('update-downloaded', (info) => {
     updateStatus(constants.UPDATE_READY, info);
   });
-  
+
   autoUpdater.on('error', (err) => {
     updateStatus(constants.UPDATE_ERROR, err.message);
     Sentry.captureException(err);

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,11 +1,11 @@
-import { app, BrowserWindow, ipcMain as ipc } from 'electron';
+import {app, BrowserWindow, ipcMain as ipc} from 'electron';
 import localShortcut from 'electron-localshortcut';
 import browserLauncher from '@james-proxy/james-browser-launcher';
 import * as Sentry from '@sentry/node';
 
-import constants from 'common/constants.js';
-import config from 'common/config.js';
-import sentryInit from 'common/service/sentry.js';
+import constants from '../common/constants.js';
+import config from '../common/config.js';
+import sentryInit from '../common/service/sentry.js';
 
 import createMenu from './menu.js';
 import createUrlMapper from './url-mapper.js';
@@ -85,8 +85,7 @@ app.on('ready', () => {
   });
 
   ipc.on('proxy-get-request', (evt, {id}) => {
-    const request = proxy.getRequest(id);
-    evt.returnValue = request; // note: not async
+    evt.returnValue = proxy.getRequest(id); // note: not async
   });
 
   ipc.on('proxy-cache-toggle', (evt, {enabled}) => {

--- a/src/main/proxy.js
+++ b/src/main/proxy.js
@@ -2,10 +2,10 @@ import hoxy from 'hoxy';
 import fs from 'fs';
 import EventEmitter from 'events';
 
-import constants from 'common/constants.js';
-import appConfig from 'common/config.js';
+import constants from '../common/constants.js';
+import appConfig from '../common/config.js';
 
-import Proxy from 'common/service/proxy.js';
+import Proxy from '../common/service/proxy.js';
 
 class ProxyHandler extends EventEmitter {
   constructor(config, urlMapper) {

--- a/src/main/url-mapper.js
+++ b/src/main/url-mapper.js
@@ -1,7 +1,7 @@
 import Datastore from 'nedb';
 import EventEmitter from 'events';
 
-import UrlMapper from 'common/service/url-mapper.js';
+import UrlMapper from '../common/service/url-mapper.js';
 
 class UrlMapperHandler extends EventEmitter {
   constructor(config) {

--- a/src/renderer/component/footer/footer.js
+++ b/src/renderer/component/footer/footer.js
@@ -8,16 +8,16 @@ import RequestCount from './request-count.js';
 import ProxyStatus from './proxy-status.js';
 import UpdateStatus from './update-status';
 
-import { 
+import {
   ProxyStatus as ProxyStatusTypes,
   UpdateStatus as UpdateStatusTypes
-} from 'common/prop-types';
+} from '../../../common/prop-types';
 import {
   toggleCaching,
   toggleThrottling as toggleThrottle,
   setThrottleRate,
   clearRequests
-} from 'common/actions/proxy.js';
+} from '../../../common/actions/proxy.js';
 
 import { getUpdateStatus } from '../../reducers/app.js';
 import { getRequestData } from '../../reducers/requests.js';

--- a/src/renderer/component/footer/proxy-status.js
+++ b/src/renderer/component/footer/proxy-status.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import constants from 'common/constants.js';
-import { ProxyStatus as ProxyStatusTypes } from 'common/prop-types.js';
+import constants from '../../../common/constants.js';
+import { ProxyStatus as ProxyStatusTypes } from '../../../common/prop-types.js';
 
 const iconMap = {
   [constants.PROXY_STATUS_STARTING]: 'fa-hourglass-half',

--- a/src/renderer/component/footer/update-status.js
+++ b/src/renderer/component/footer/update-status.js
@@ -3,9 +3,9 @@ import { shell } from 'electron';
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import constants from 'common/constants.js';
-import config from 'common/config.js';
-import { UpdateStatus as UpdateStatusTypes } from 'common/prop-types';
+import constants from '../../../common/constants.js';
+import config from '../../../common/config.js';
+import { UpdateStatus as UpdateStatusTypes } from '../../../common/prop-types';
 
 const launchURL = (e, url) => {
   e.preventDefault();

--- a/src/renderer/component/home/browsers.js
+++ b/src/renderer/component/home/browsers.js
@@ -30,7 +30,7 @@ Browsers.propTypes = {
 };
 
 
-import { launchBrowser } from 'common/actions/browsers.js';
+import { launchBrowser } from '../../../common/actions/browsers.js';
 import { getBrowsers } from '../../reducers/browsers.js';
 
 const mapStateToProps = (state) => ({

--- a/src/renderer/component/inspect-request/inspect-request.js
+++ b/src/renderer/component/inspect-request/inspect-request.js
@@ -38,7 +38,7 @@ InspectRequest.propTypes = {
   clearActiveRequest: PropTypes.func.isRequired
 };
 
-import { setActiveRequest } from 'common/actions/requests.js';
+import { setActiveRequest } from '../../../common/actions/requests.js';
 import { getActiveRequest } from '../../reducers/requests.js';
 
 const mapStateToProps = (state) => ({

--- a/src/renderer/component/mapping/new-mapping-destination.js
+++ b/src/renderer/component/mapping/new-mapping-destination.js
@@ -4,7 +4,7 @@ import {remote} from 'electron';
 
 import Errors from '../errors/errors.js';
 
-import createChooseFile from 'common/service/choose-file.js';
+import createChooseFile from '../../../common/service/choose-file.js';
 
 const NewMappingDestination = (props) => {
   const {isLocal, destination, update, create, cancel, errors = []} = props;

--- a/src/renderer/component/mapping/new-mapping.js
+++ b/src/renderer/component/mapping/new-mapping.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import constants from 'common/constants.js';
+import constants from '../../../common/constants.js';
 
 import NewMappingTarget from './new-mapping-target.js';
 import NewMappingDestination from './new-mapping-destination.js';
@@ -117,7 +117,7 @@ NewMapping.propTypes = {
   mapping: PropTypes.object
 };
 
-import { updateNewMapping, nextNewMapping, resetNewMapping, setNewMappingError } from 'common/actions/url-mappings.js';
+import { updateNewMapping, nextNewMapping, resetNewMapping, setNewMappingError } from '../../../common/actions/url-mappings.js';
 import { getNewMapping } from '../../reducers/url-mappings.js';
 
 const mapStateToProps = (state) => ({

--- a/src/renderer/component/requests/request-context-menu.js
+++ b/src/renderer/component/requests/request-context-menu.js
@@ -59,7 +59,7 @@ import {
   showAddUrlMapping,
   toggleUrlMapping,
   removeUrlMapping
-} from 'common/actions/url-mappings.js';
+} from '../../../common/actions/url-mappings.js';
 
 const mapDispatchToProps = {
   showAddMapping: showAddUrlMapping,

--- a/src/renderer/component/requests/requests.js
+++ b/src/renderer/component/requests/requests.js
@@ -36,7 +36,7 @@ Requests.propTypes = {
   handleContextMenu: PropTypes.func.isRequired
 };
 
-import { setActiveRequest, setContextRequest } from 'common/actions/requests.js';
+import { setActiveRequest, setContextRequest } from '../../../common/actions/requests.js';
 import { getRequestData, getActiveRequest, getContextRequest } from '../../reducers/requests.js';
 import { getLabels } from '../../reducers/app.js';
 

--- a/src/renderer/component/requests/search.js
+++ b/src/renderer/component/requests/search.js
@@ -40,7 +40,7 @@ Search.propTypes = {
 };
 
 
-import { setRequestFilter } from 'common/actions/requests.js';
+import { setRequestFilter } from '../../../common/actions/requests.js';
 import { getRequestFilter } from '../../reducers/requests.js';
 
 const mapStateToProps = (state) => ({

--- a/src/renderer/component/title-bar/title-bar.js
+++ b/src/renderer/component/title-bar/title-bar.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
 
-import { toggleDevTools } from 'common/service/dev-tools.js';
+import { toggleDevTools } from '../../../common/service/dev-tools.js';
 
 import MappingCount from './mapping-count.js';
 

--- a/src/renderer/containers/requests.js
+++ b/src/renderer/containers/requests.js
@@ -34,7 +34,7 @@ RequestsContainer.propTypes = {
 };
 
 
-import { setContextRequest } from 'common/actions/requests.js';
+import { setContextRequest } from '../../common/actions/requests.js';
 import { hasRequests } from '../reducers/requests.js';
 
 const mapStateToProps = (state) => ({

--- a/src/renderer/containers/url-mappings.js
+++ b/src/renderer/containers/url-mappings.js
@@ -41,7 +41,7 @@ UrlMappingsContainer.propTypes = {
 };
 
 
-import { setUrlMapping, toggleUrlMapping, removeUrlMapping } from 'common/actions/url-mappings.js';
+import { setUrlMapping, toggleUrlMapping, removeUrlMapping } from '../../common/actions/url-mappings.js';
 import { getMappings } from '../reducers/url-mappings.js';
 
 const mapStateToProps = (state) => ({

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -1,4 +1,4 @@
-import constants from 'common/constants.js';
+import constants from '../common/constants.js';
 
 if (!constants.DEV) { // fix for loading async bundles (see electron-userland/electron-webpack#70)
   __webpack_public_path__ = `file:///${process.resourcesPath}/app.asar/`;  // eslint-disable-line camelcase
@@ -13,17 +13,17 @@ import createHistory from 'history/createHashHistory';
 import throttle from 'lodash.throttle';
 import * as Sentry from '@sentry/browser';
 
-import config from 'common/config.js';
-import sentryInit from 'common/service/sentry.js';
-import setupShortcuts from 'common/service/shortcuts.js';
+import config from '../common/config.js';
+import sentryInit from '../common/service/sentry.js';
+import setupShortcuts from '../common/service/shortcuts.js';
 
 import setupStore from './store/index.js';
 
-import { init, setUpdaterStatus } from 'common/actions/app.js';
-import { syncRequests } from 'common/actions/requests.js';
-import { updateProxyStatus } from 'common/actions/proxy.js';
-import { syncUrlMappings } from 'common/actions/url-mappings.js';
-import { addBrowsers } from 'common/actions/browsers.js';
+import { init, setUpdaterStatus } from '../common/actions/app.js';
+import { syncRequests } from '../common/actions/requests.js';
+import { updateProxyStatus } from '../common/actions/proxy.js';
+import { syncUrlMappings } from '../common/actions/url-mappings.js';
+import { addBrowsers } from '../common/actions/browsers.js';
 
 import App from './containers/app';
 

--- a/src/renderer/reducers/app.js
+++ b/src/renderer/reducers/app.js
@@ -1,7 +1,7 @@
 import { combineReducers } from 'redux';
 
-import constants from 'common/constants.js';
-import * as actions from 'common/actions/app.js';
+import constants from '../../common/constants.js';
+import * as actions from '../../common/actions/app.js';
 
 const initialState = {
   config: {},

--- a/src/renderer/reducers/browsers.js
+++ b/src/renderer/reducers/browsers.js
@@ -1,6 +1,6 @@
 import { combineReducers } from 'redux';
 
-import * as actions from 'common/actions/browsers.js';
+import * as actions from '../../common/actions/browsers.js';
 
 const initialState = {
   browsers: []

--- a/src/renderer/reducers/proxy.js
+++ b/src/renderer/reducers/proxy.js
@@ -1,8 +1,8 @@
 import { combineReducers } from 'redux';
 
-import constants from 'common/constants.js';
+import constants from '../../common/constants.js';
 
-import * as actions from 'common/actions/proxy.js';
+import * as actions from '../../common/actions/proxy.js';
 
 const initialState = {
   status: constants.PROXY_STATUS_STARTING,

--- a/src/renderer/reducers/requests.js
+++ b/src/renderer/reducers/requests.js
@@ -1,6 +1,6 @@
 import { combineReducers } from 'redux';
 
-import * as actions from 'common/actions/requests.js';
+import * as actions from '../../common/actions/requests.js';
 
 const initialState = {
   filter: null,

--- a/src/renderer/reducers/url-mappings.js
+++ b/src/renderer/reducers/url-mappings.js
@@ -1,8 +1,7 @@
 import { combineReducers } from 'redux';
 
-import constants from 'common/constants.js';
-
-import * as actions from 'common/actions/url-mappings.js';
+import constants from '../../common/constants.js';
+import * as actions from '../../common/actions/url-mappings.js';
 
 const initialState = {
   mappings: [],

--- a/src/renderer/store/index.js
+++ b/src/renderer/store/index.js
@@ -3,7 +3,7 @@ import thunkMiddleware from 'redux-thunk';
 import { createLogger } from 'redux-logger';
 import { routerMiddleware } from 'react-router-redux';
 
-import constants from 'common/constants.js';
+import constants from '../../common/constants.js';
 
 import urlMapperMiddleware from './middleware/url-mapper.js';
 import proxyMiddleware from './middleware/proxy.js';

--- a/src/renderer/store/middleware/proxy.js
+++ b/src/renderer/store/middleware/proxy.js
@@ -1,7 +1,7 @@
 import { ipcRenderer as ipc } from 'electron';
 
-import * as actions from 'common/actions/proxy.js';
-import * as requestActions from 'common/actions/requests.js';
+import * as actions from '../../../common/actions/proxy.js';
+import * as requestActions from '../../../common/actions/requests.js';
 
 const middleware = store => next => action => {
   // grab full data from main process before reducers

--- a/src/renderer/store/middleware/sentry.js
+++ b/src/renderer/store/middleware/sentry.js
@@ -1,9 +1,9 @@
 import * as Sentry from '@sentry/browser';
 
-import constants from 'common/constants.js';
+import constants from '../../../common/constants.js';
 
-import { SYNC_REQUESTS } from 'common/actions/requests.js';
-import { SYNC_URL_MAPPINGS } from 'common/actions/url-mappings.js';
+import { SYNC_REQUESTS } from '../../../common/actions/requests.js';
+import { SYNC_URL_MAPPINGS } from '../../../common/actions/url-mappings.js';
 
 const middleware = () => next => action => {
   if (constants.DEV) {

--- a/src/renderer/store/middleware/url-mapper.js
+++ b/src/renderer/store/middleware/url-mapper.js
@@ -1,6 +1,6 @@
 import { ipcRenderer as ipc } from 'electron';
 
-import * as actions from 'common/actions/url-mappings.js';
+import * as actions from '../../../common/actions/url-mappings.js';
 
 const middleware = () => next => action => {
   const mapping = action.mapping;

--- a/test/unit/actions/browsers.js
+++ b/test/unit/actions/browsers.js
@@ -1,12 +1,12 @@
 import assert from 'assert';
 
-import * as actions from 'common/actions/browsers.js';
+import * as actions from '../../../src/common/actions/browsers.js';
 
 const browsers = [{}];
 
 describe('browser actions', () => {
   // TODO: detectBrowsers, launchBrowser
-  
+
   it('should create an action to add browsers (default)', () => {
     const expectedAction = {
       type: actions.ADD_BROWSERS,

--- a/test/unit/actions/proxy.js
+++ b/test/unit/actions/proxy.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
 
-import * as actions from 'common/actions/proxy.js';
-import constants from 'common/constants.js';
+import * as actions from '../../../src/common/actions/proxy.js';
+import constants from '../../../src/common/constants.js';
 
 describe('proxy actions', () => {
   it('should create an action to toggle caching', () => {

--- a/test/unit/actions/requests.js
+++ b/test/unit/actions/requests.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-import * as actions from 'common/actions/requests.js';
+import * as actions from '../../../src/common/actions/requests.js';
 
 const request = {
   request: {},

--- a/test/unit/actions/url-mappings.js
+++ b/test/unit/actions/url-mappings.js
@@ -3,8 +3,8 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { push } from 'react-router-redux';
 
-import * as actions from 'common/actions/url-mappings.js';
-import constants from 'common/constants.js';
+import * as actions from '../../../src/common/actions/url-mappings.js';
+import constants from '../../../src/common/constants.js';
 
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);

--- a/test/unit/reducers/proxy.js
+++ b/test/unit/reducers/proxy.js
@@ -1,8 +1,8 @@
 import assert from 'assert';
 
-import proxy from 'renderer/reducers/proxy.js';
-import * as actions from 'common/actions/proxy.js';
-import constants from 'common/constants.js';
+import proxy from '../../../src/renderer/reducers/proxy.js';
+import * as actions from '../../../src/common/actions/proxy.js';
+import constants from '../../../src/common/constants.js';
 
 const initialState = {
   status: constants.PROXY_STATUS_STARTING,

--- a/test/unit/reducers/url-mappings.js
+++ b/test/unit/reducers/url-mappings.js
@@ -1,8 +1,8 @@
 import assert from 'assert';
 
-import * as actions from 'common/actions/url-mappings.js';
-import constants from 'common/constants.js';
-import urlMappings from 'renderer/reducers/url-mappings.js';
+import * as actions from '../../../src/common/actions/url-mappings.js';
+import constants from '../../../src/common/constants.js';
+import urlMappings from '../../../src/renderer/reducers/url-mappings.js';
 
 const initialState = {
   mappings: [],

--- a/test/unit/service/proxy-spec.js
+++ b/test/unit/service/proxy-spec.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import sinon from 'sinon';
 
-import Proxy from 'common/service/proxy.js';
+import Proxy from '../../../src/common/service/proxy.js';
 
 describe('Proxy', function() {
   const update = () => {

--- a/test/unit/service/url-mapper-spec.js
+++ b/test/unit/service/url-mapper-spec.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import sinon from 'sinon';
 
-import UrlMapper from 'common/service/url-mapper.js';
+import UrlMapper from '../../../src/common/service/url-mapper.js';
 
 describe('url mapper', function() {
   const update = sinon.spy();

--- a/webpack.test.config.js
+++ b/webpack.test.config.js
@@ -1,5 +1,3 @@
-const path = require('path');
-
 module.exports = {
   module: {
     rules: [
@@ -29,13 +27,6 @@ module.exports = {
         }
       }
     ]
-  },
-  resolve: {
-    alias: {
-      common: path.join(__dirname, '/src/common'),
-      renderer: path.join(__dirname, '/src/renderer'),
-      main: path.join(__dirname, '/src/main'),
-    }
   },
   target: 'node',
   externals: [


### PR DESCRIPTION
Right now, the imports depend on webpack configuration (top-level `resolve` aliases).
However, most IDE's don't parse this, so using functions from other files requires a manual import, which is annoying. It's more convenient if your IDE does your imports for you, if possible.