### PR TITLE
Uses a key for the array used in request-details

### DIFF
--- a/src/renderer/component/inspect-request/request-details.js
+++ b/src/renderer/component/inspect-request/request-details.js
@@ -44,8 +44,8 @@ export default class RequestDetails extends React.Component {
       <RequestBody body={request.request.body} title="Request Body"/>
       {request.response.body ?
         [
-          <RequestMetadata metadata={request.response.headers} title="Response Headers"/>,
-          <RequestBody body={request.response.body} title="Response Body"/>
+          <RequestMetadata metadata={request.response.headers} title="Response Headers" key="response-header"/>,
+          <RequestBody body={request.response.body} title="Response Body" key="response-body"/>
         ]
         : null
       }


### PR DESCRIPTION
The alternative is to wrap the dependent-on-body elements in a `<div>` (or some parent element), but I didn't want to unnecessarily dirty the DOM