### PR TITLE
Use patched version of hoxy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/proxy"]
+	path = src/proxy
+	url = git@github.com:jamezrin/hoxy.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/proxy"]
 	path = src/proxy
-	url = git@github.com:jamezrin/hoxy.git
+	url = https://github.com/jamezrin/hoxy.git

--- a/package-lock.json
+++ b/package-lock.json
@@ -6241,9 +6241,7 @@
       "dev": true
     },
     "hoxy": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/hoxy/-/hoxy-3.3.1.tgz",
-      "integrity": "sha512-zIsDm6a/FAN9XgFp2xkkDl8MfcHM5HOJL9oN5cGO6j1cMPAKEbT4iBhlhvrmnavwKx0EBzUOBtw7Q218otFsYQ==",
+      "version": "file:src/proxy",
       "requires": {
         "await": "^0.2.5",
         "babel-runtime": "^5.7.0",
@@ -6264,13 +6262,11 @@
       "dependencies": {
         "bluebird": {
           "version": "2.11.0",
-          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+          "bundled": true
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "bundled": true
         }
       }
     },
@@ -7359,9 +7355,9 @@
       }
     },
     "limiter": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.3.tgz",
-      "integrity": "sha512-zrycnIMsLw/3ZxTbW7HCez56rcFGecWTx5OZNplzcXUUmJLmoYArC6qdJzmAN5BWiNXGcpjhF9RQ1HSv5zebEw=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.4.tgz",
+      "integrity": "sha512-XCpr5bElgDI65vVgstP8TWjv6/QKWm9GU5UG0Pr5sLQ3QLo8NVKsioe+Jed5/3vFOe3IQuqE7DKwTvKQkjTHvg=="
     },
     "load-json-file": {
       "version": "1.1.0",
@@ -7429,7 +7425,7 @@
     },
     "lodash": {
       "version": "3.10.1",
-      "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
       "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
     },
     "lodash-es": {
@@ -8619,15 +8615,15 @@
       }
     },
     "nodemon": {
-      "version": "1.18.8",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.18.8.tgz",
-      "integrity": "sha512-CgC/JdCf+CT7Z+K6wWaV30t8GU1DPtXpr/6PuXC1/LboXCmUQNKOaz0AEMjoWDTt2AdHOBFxgv41dyC0i79SbA==",
+      "version": "1.18.9",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.18.9.tgz",
+      "integrity": "sha512-oj/eEVTEI47pzYAjGkpcNw0xYwTl4XSTUQv2NPQI6PpN3b75PhpuYk3Vb3U80xHCyM2Jm+1j68ULHXl4OR3Afw==",
       "requires": {
         "chokidar": "^2.0.4",
         "debug": "^3.1.0",
         "ignore-by-default": "^1.0.1",
         "minimatch": "^3.0.4",
-        "pstree.remy": "^1.1.3",
+        "pstree.remy": "^1.1.6",
         "semver": "^5.5.0",
         "supports-color": "^5.2.0",
         "touch": "^3.1.0",
@@ -9246,9 +9242,9 @@
       }
     },
     "pem": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/pem/-/pem-1.13.2.tgz",
-      "integrity": "sha512-MPJWuEb/r6AG+GpZi2JnfNtGAZDeL/8+ERKwXEWRuST5i+4lq/Uy36B352OWIUSPQGH+HR1HEDcIDi+8cKxXNg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/pem/-/pem-1.14.1.tgz",
+      "integrity": "sha512-WY3IzMoh+Gwp4xJTT2MqIOaVzNqU7jHqj7k0pOnLIkNSnOpjhy3PHr9mXGi+C5tRC2z1EX5lvzEbd9BtHumHLQ==",
       "requires": {
         "es6-promisify": "^6.0.0",
         "md5": "^2.2.1",
@@ -12013,9 +12009,9 @@
       "dev": true
     },
     "pstree.remy": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.4.tgz",
-      "integrity": "sha512-3kSyTN/iTJMxtL87idnFgTyOp2vQ6B/49QcHUO26kh2M2qahlUivFI1zWJ9FRFPoB+KgcP820JMOuIhkBJAP3Q=="
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.6.tgz",
+      "integrity": "sha512-NdF35+QsqD7EgNEI5mkI/X+UwaxVEbQaz9f4IooEmMUv6ZPmlTQYGjBPJGgrlzNdjSvIy4MWMg6Q6vCgBO2K+w=="
     },
     "public-encrypt": {
       "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "electron-updater": "3.1.2",
     "font-awesome": "^4.5.0",
     "history": "^4.7.2",
-    "hoxy": "^3.3.1",
+    "hoxy": "file:./src/proxy",
     "lodash.throttle": "^4.1.0",
     "materialize-css": "^0.100.2",
     "nedb": "^1.7.1",

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -24,11 +24,6 @@ const urlMapper = createUrlMapper({
   autoload: true
 });
 
-process.on('uncaughtException', (error) => {
-  // TODO remove this global handler!
-  console.warn('Ignored fatal error!', error); // eslint-disable-line no-console
-});
-
 console.log('Starting proxy...'); // eslint-disable-line no-console
 const proxy = createProxy(config, urlMapper.urlMapper);
 


### PR DESCRIPTION
The patched version propagates exceptions created by the sockets to the main event emitter, check https://github.com/greim/hoxy/pull/110

The force push is because I accidentally reverted https://github.com/james-proxy/james/pull/406/commits/97993f47d011cf6a89d56dad91c3b1630d1c5735 which would remove the changelog entry for the previous release, so I deleted the handler myself

It works locally, but I think the way I have done this makes no sense (the submodules) so sorry for this, I wanted the commits I created to be visible, but I could've just set my repository on the package.json, but for some reason that wasn't working well when `npm install`ing.

I don't think the PR to hoxy will get merged, it is not maintainted. So maybe the james-proxy can fork it with that fix in it? 
