### PR TITLE
Updates sentry, removes UncaughtException integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -944,76 +944,77 @@
       "dev": true
     },
     "@sentry/browser": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-4.4.2.tgz",
-      "integrity": "sha512-km5p3hPz+aoY4UiEvYxAdRJAbIK30urZSuMs/3zAUVe+8Zij0IHjHmdi9JtrMqpn+rAcWCxtRmFSYlkiKjdSUg==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-4.5.3.tgz",
+      "integrity": "sha512-ePbsyXtZS9jWM0lD8rxA46omJjJcQPaRZak08TyxFBGm1YOUFvvNAA6rNjUtK4fFEznLhPA5YcllcOCBE2bPPg==",
       "requires": {
-        "@sentry/core": "4.4.2",
-        "@sentry/types": "4.4.2",
-        "@sentry/utils": "4.4.2",
+        "@sentry/core": "4.5.3",
+        "@sentry/types": "4.5.3",
+        "@sentry/utils": "4.5.3",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/core": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-4.4.2.tgz",
-      "integrity": "sha512-hJyAodTCf4sZfVdf41Rtuzj4EsyzYq5rdMZ+zc2Vinwdf8D0/brHe91fHeO0CKXEb2P0wJsrjwMidG/ccq/M8A==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-4.5.3.tgz",
+      "integrity": "sha512-off7XkyyiPXJTQ1XYPzxsY3zLHztMdK1kuIeHzyoIzu4kvs8H75eqou+fADo04JmfaMNy+OZSoW+5Aq2SZR2Ng==",
       "requires": {
-        "@sentry/hub": "4.4.2",
-        "@sentry/minimal": "4.4.2",
-        "@sentry/types": "4.4.2",
-        "@sentry/utils": "4.4.2",
+        "@sentry/hub": "4.5.3",
+        "@sentry/minimal": "4.5.3",
+        "@sentry/types": "4.5.3",
+        "@sentry/utils": "4.5.3",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-4.4.2.tgz",
-      "integrity": "sha512-oe9ytXkTWyD+QmOpVzHAqTbRV4Hc0ee2Nt6HvrDtRmlXzQxfvTWG2F8KYT6w8kzqg5klnuRpnsmgTTV3KuNBVQ==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-4.5.3.tgz",
+      "integrity": "sha512-4b8oPVAGw/hf11CQN9J7hAk2wzD2HIZsQBl/PcB/p5r1UyHw8cibpVobJulkHJMBJMiZ/twIBGZ1G1qK3LJdhw==",
       "requires": {
-        "@sentry/types": "4.4.2",
-        "@sentry/utils": "4.4.2",
+        "@sentry/types": "4.5.3",
+        "@sentry/utils": "4.5.3",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-4.4.2.tgz",
-      "integrity": "sha512-GEZZiNvVgqFAESZhAe3vjwTInn13lI2bSI3ItQN4RUWKL/W4n/fwVoDJbkb1U8aWxanuMnRDEpKwyQv6zYTZfw==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-4.5.3.tgz",
+      "integrity": "sha512-W9+eEZosoDKTAJkab/bxsSRim7I4lqeWHLhmCchDimKcdmpBzC+gOCT0PywwOWRLW08LhTHfmnNSAJv6PaZiCA==",
       "requires": {
-        "@sentry/hub": "4.4.2",
-        "@sentry/types": "4.4.2",
+        "@sentry/hub": "4.5.3",
+        "@sentry/types": "4.5.3",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-4.4.2.tgz",
-      "integrity": "sha512-8/KlSdfVhledZ6PS6muxZY5r2pqhw8MNSXP7AODR2qRrHwsbnirVgV21WIAYAjKXEfYQGbm69lyoaTJGazlQ3Q==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-4.5.3.tgz",
+      "integrity": "sha512-glBIGsoYDcUEjZWDjbkDWt87cmuO/lcxpfz4zfTq9JfIfzI3WunJqABhFDc8tQSqUdHOlWb2QKvoNPvz+0EDfg==",
       "requires": {
-        "@sentry/core": "4.4.2",
-        "@sentry/hub": "4.4.2",
-        "@sentry/types": "4.4.2",
-        "@sentry/utils": "4.4.2",
+        "@sentry/core": "4.5.3",
+        "@sentry/hub": "4.5.3",
+        "@sentry/types": "4.5.3",
+        "@sentry/utils": "4.5.3",
         "@types/stack-trace": "0.0.29",
         "cookie": "0.3.1",
-        "https-proxy-agent": "^2.2.1",
+        "https-proxy-agent": "2.2.1",
+        "lru_map": "0.3.3",
         "lsmod": "1.0.0",
         "stack-trace": "0.0.10",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-4.4.2.tgz",
-      "integrity": "sha512-QyQd6PKKIyjJgaq/RQjsxPJEWbXcuiWZ9RvSnhBjS5jj53HEzkM1qkbAFqlYHJ1DTJJ1EuOM4+aTmGzHe93zuA=="
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-4.5.3.tgz",
+      "integrity": "sha512-7ll1PAFNjrBNX9rzy3P2qAQrpQwHaDO3uKj735qsnGw34OtAS8Xr8WYrjI14f9fMPa/XIeWvMPb4GMic28V/ag=="
     },
     "@sentry/utils": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-4.4.2.tgz",
-      "integrity": "sha512-j/Ad8G1abHlJdD2q7aWWbSOSeWB5M5v1R1VKL8YPlwEbSvvmEQWePhBKFI0qlnKd2ObdUQsj86pHEXJRSFNfCw==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-4.5.3.tgz",
+      "integrity": "sha512-yIYqnuq9cd9nAUJ2MPmq++Mgy81qB2fglsDB8TiBfk2eaba79qFcKp8xg3w3EMDHZMlfmlx4fkTmZJ/+V02oWQ==",
       "requires": {
-        "@sentry/types": "4.4.2",
+        "@sentry/types": "4.5.3",
         "tslib": "^1.9.3"
       }
     },
@@ -7558,6 +7559,11 @@
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
+    },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
     },
     "lsmod": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   },
   "dependencies": {
     "@james-proxy/james-browser-launcher": "^1.3.2",
-    "@sentry/browser": "^4.0.2",
-    "@sentry/node": "^4.0.1",
+    "@sentry/browser": "^4.5.3",
+    "@sentry/node": "^4.5.3",
     "electron-updater": "3.1.2",
     "font-awesome": "^4.5.0",
     "history": "^4.7.2",

--- a/src/common/service/sentry.js
+++ b/src/common/service/sentry.js
@@ -9,6 +9,7 @@ export default function init(app, Sentry) {
   const { dsn, host } = config.sentry;
   Sentry.init({
     dsn: `https://${dsn}@${host}`,
-    release: config.version(app)
+    release: config.version(app),
+    defaultIntegrations
   });
 }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -19,10 +19,11 @@ import * as sentryNode from '@sentry/node';
 // See bug: https://github.com/james-proxy/james/issues/405
 process.on('uncaughtException', (error) => {
   console.warn('Ignored fatal error!', error); // eslint-disable-line no-console
+  Sentry.captureException(error);
 });
 
 // Replace default onFatalError implementation (that kills the process) with a noop
-// Uncaught exceptions will NOT be reported to Sentry!
+// Uncaught exceptions will be reported to exceptions manually in our override handler above
 const defaultIntegrations = sentryNode.defaultIntegrations
   .filter(integration => !(integration instanceof sentryNode.Integrations.OnUncaughtException));
 


### PR DESCRIPTION
Fixes #405.

-----

`hoxy` is currently throwing various uncaught exceptions when using HTTPs.
#406 should've caught that so that James didn't go down, but, unfortunately, [Sentry is opinionated](https://github.com/getsentry/sentry-javascript/blob/master/packages/node/src/integrations/onuncaughtexception.ts#L78) and kills our application when it finds out about the uncaught exception.

This rolls back our Sentry usage a bit so that James doesn't crash. The proper, long-term solution will be to resolve this issue in `hoxy` (or use equivalent proxy solution)